### PR TITLE
Use non-block wait for confirmations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/*.rs.bk
 
 /abi/
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
-web3 = { git = "https://github.com/polyswarm/rust-web3.git", branch = "relay" }
+web3 = { git = "https://github.com/polyswarm/rust-web3.git", branch = "relay2" }
 consul = { git = "https://github.com/polyswarm/consul-rust", branch = "master" }
 base64 = "0.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
-web3 = { git = "https://github.com/polyswarm/rust-web3.git", branch = "relay2" }
+web3 = { git = "https://github.com/polyswarm/rust-web3.git", branch = "fix/non-blocking-poll-confirmations" }
 consul = { git = "https://github.com/polyswarm/consul-rust", branch = "master" }
 base64 = "0.9.3"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,12 @@
 FROM rust
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
+ENV DOCKERIZE_VERSION v0.6.1
+
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 # # create a new empty shell project
 RUN USER=root cargo new --bin polyswarm-relay
 WORKDIR /polyswarm-relay

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -9,4 +9,4 @@
     ws-uri = "ws://sidechain:8546"
 
 [logging]
-    format = "json"
+    format = "raw"

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -323,8 +323,18 @@ impl<T: DuplexTransport + 'static> Network<T> {
                                         time::Duration::from_secs(1),
                                         confirmations,
                                     ).and_then(move |receipt| {
-                                        let block_hash = receipt.block_hash;
-                                        let block_number = receipt.block_number;
+                                        if receipt.block_number.is_none() {
+                                            warn!("no block number in transfer receipt");
+                                            return Ok(())
+                                        }
+
+                                        if receipt.block_hash.is_none() {
+                                            warn!("no block hash in transfer receipt");
+                                            return Ok(())
+                                        }
+
+                                        let block_hash = receipt.block_hash.unwrap();
+                                        let block_number = receipt.block_number.unwrap();
 
                                         let transfer = Transfer {
                                             destination,
@@ -395,28 +405,36 @@ impl<T: DuplexTransport + 'static> Network<T> {
                                             web3.eth()
                                                 .block(block_id)
                                                 .and_then(move |block| {
-                                                    if block.number.is_none() {
-                                                        warn!("no block number in anchor block");
-                                                        return Ok(());
+                                                    match block {
+                                                        Some(b) => {
+                                                            if b.number.is_none() {
+                                                                warn!("no block number in anchor block");
+                                                                return Ok(());
+                                                            }
+
+                                                            if b.hash.is_none() {
+                                                                warn!("no block hash in anchor block");
+                                                                return Ok(());
+                                                            }
+
+                                                            let block_hash: H256 = b.hash.unwrap();
+                                                            let block_number: U256 = b.number.unwrap().into();
+
+                                                            let anchor = Anchor {
+                                                                block_hash,
+                                                                block_number,
+                                                            };
+
+                                                            info!("anchor block confirmed, anchoring: {}", &anchor);
+
+                                                            tx.unbounded_send(anchor).unwrap();
+                                                            Ok(())
+                                                        },
+                                                        None => {
+                                                            warn!("no block found for anchor confirmations");
+                                                            Ok(())
+                                                        }
                                                     }
-
-                                                    if block.hash.is_none() {
-                                                        warn!("no block hash in anchor block");
-                                                        return Ok(());
-                                                    }
-
-                                                    let block_hash: H256 = block.hash.unwrap();
-                                                    let block_number: U256 = block.number.unwrap().into();
-
-                                                    let anchor = Anchor {
-                                                        block_hash,
-                                                        block_number,
-                                                    };
-
-                                                    info!("anchor block confirmed, anchoring: {}", &anchor);
-
-                                                    tx.unbounded_send(anchor).unwrap();
-                                                    Ok(())
                                                 }).or_else(|e| {
                                                     error!("error waiting for anchor confirmations: {}", e);
                                                     Ok(())


### PR DESCRIPTION
Relay was processing transaction sequentially, resulting in 22 blocks between each transfer. 