### PR TITLE
Respect CONSUL_TOKEN, some cleanup

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,3 @@
-#![allow(redundant_field_names)]
 use log::Level;
 use settings::Logging;
 use std::io::stderr;
@@ -10,14 +9,6 @@ pub fn flush() {
     // implemented `flush` anyway to this to ensure no termios emit bugs
     let _ = stderr().flush();
 }
-
-macro_rules! logln(
-    ($($arg:tt)*) => { {
-        use std::io::Write;
-        let r = writeln!(&mut ::std::io::stderr(), $($arg)*);
-        r.expect("failed printing to stderr");
-    } }
-);
 
 mod raw_logger {
     use log::{Level, Log, Metadata, Record};
@@ -34,7 +25,7 @@ mod raw_logger {
 
         fn log(&self, record: &Record) {
             if self.enabled(record.metadata()) {
-                logln!(
+                eprintln!(
                     "{} {:<5} [{}] {}",
                     self.name,
                     record.level().to_string(),
@@ -83,7 +74,7 @@ mod json_logger {
             });
 
             if self.enabled(record.metadata()) {
-                logln!("{}", json_record.to_string());
+                eprintln!("{}", json_record.to_string());
             }
         }
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -351,12 +351,12 @@ impl<T: DuplexTransport + 'static> Network<T> {
                                     ).and_then(move |receipt| {
                                         if receipt.block_number.is_none() {
                                             warn!("no block number in transfer receipt");
-                                            return Ok(())
+                                            return Ok(());
                                         }
 
                                         if receipt.block_hash.is_none() {
                                             warn!("no block hash in transfer receipt");
-                                            return Ok(())
+                                            return Ok(());
                                         }
 
                                         let block_hash = receipt.block_hash.unwrap();
@@ -430,36 +430,34 @@ impl<T: DuplexTransport + 'static> Network<T> {
                                         handle.spawn(
                                             web3.eth()
                                                 .block(block_id)
-                                                .and_then(move |block| {
-                                                    match block {
-                                                        Some(b) => {
-                                                            if b.number.is_none() {
-                                                                warn!("no block number in anchor block");
-                                                                return Ok(());
-                                                            }
-
-                                                            if b.hash.is_none() {
-                                                                warn!("no block hash in anchor block");
-                                                                return Ok(());
-                                                            }
-
-                                                            let block_hash: H256 = b.hash.unwrap();
-                                                            let block_number: U256 = b.number.unwrap().into();
-
-                                                            let anchor = Anchor {
-                                                                block_hash,
-                                                                block_number,
-                                                            };
-
-                                                            info!("anchor block confirmed, anchoring: {}", &anchor);
-
-                                                            tx.unbounded_send(anchor).unwrap();
-                                                            Ok(())
-                                                        },
-                                                        None => {
-                                                            warn!("no block found for anchor confirmations");
-                                                            Ok(())
+                                                .and_then(move |block| match block {
+                                                    Some(b) => {
+                                                        if b.number.is_none() {
+                                                            warn!("no block number in anchor block");
+                                                            return Ok(());
                                                         }
+
+                                                        if b.hash.is_none() {
+                                                            warn!("no block hash in anchor block");
+                                                            return Ok(());
+                                                        }
+
+                                                        let block_hash: H256 = b.hash.unwrap();
+                                                        let block_number: U256 = b.number.unwrap().into();
+
+                                                        let anchor = Anchor {
+                                                            block_hash,
+                                                            block_number,
+                                                        };
+
+                                                        info!("anchor block confirmed, anchoring: {}", &anchor);
+
+                                                        tx.unbounded_send(anchor).unwrap();
+                                                        Ok(())
+                                                    }
+                                                    None => {
+                                                        warn!("no block found for anchor confirmations");
+                                                        Ok(())
                                                     }
                                                 }).or_else(|e| {
                                                     error!("error waiting for anchor confirmations: {}", e);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,7 @@
 use config::{Config, Environment, File};
 use failure::Error;
+use std::env;
+use std::ffi::OsString;
 use std::path::Path;
 
 use super::errors::ConfigError;
@@ -70,7 +72,16 @@ impl Settings {
         c.set_default("relay.confirmations", 12)?;
         c.set_default("relay.anchor_frequency", 100)?;
         c.set_default("relay.community", "")?;
-        c.set_default("relay.consul_token", "")?;
+
+        // XXX: Get default from the CONSUL_TOKEN environment variable, look into naming such that
+        // below Environment override does this for us
+        c.set_default(
+            "relay.consul_token",
+            env::var_os("CONSUL_TOKEN")
+                .unwrap_or(OsString::from(""))
+                .to_string_lossy()
+                .to_string(),
+        )?;
 
         if let Some(p) = path {
             let ps = p.as_ref().to_str().ok_or(ConfigError::InvalidConfigFilePath)?;


### PR DESCRIPTION
infrastructure wants to pass in CONSUL_TOKEN, this preserves the config file option but allows an env var override. Config lib doesn't like underscores in names so can't depend on that override