### PR TITLE
use consul for chain id instead of config

### DIFF
--- a/config/example.toml
+++ b/config/example.toml
@@ -29,8 +29,6 @@
     free = false
     # Number of seconds between each lookback attempt
     interval = 30
-    # The chain id for the homechain Ethereum client
-    chain_id = 1337
 
 
 [relay.sidechain]
@@ -44,5 +42,3 @@
     free = true
     # Number of seconds between each lookback attempt
     interval = 30
-    # The chain id for the sidechain Ethereum client
-    chain_id = 1338

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -9,15 +9,11 @@
     wsuri = "ws://homechain:8546"
     free = false
     interval = 30
-    chain_id = 1337
-
 
 [relay.sidechain]
     wsuri = "ws://sidechain:8546"
     free = true
     interval = 30
-    chain_id = 1338
-
 
 [logging]
     format = "raw"

--- a/src/consul_configs.rs
+++ b/src/consul_configs.rs
@@ -19,14 +19,21 @@ pub fn wait_or_get(
             info!("chain for config not available in consul yet");
         }
     })?;
-
     info!("chain for {:?} config available in consul now", chain);
 
-    json[&key]
-        .as_str()
-        .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
-            Ok(v.to_string())
-        })
+    if json[&key].is_u64() {
+        json[&key]
+            .as_u64()
+            .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
+                Ok(v.to_string())
+            })
+    } else {
+        json[&key]
+            .as_str()
+            .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
+                Ok(v.to_string())
+            })
+    }
 }
 
 pub fn create_contract_abi(

--- a/src/consul_configs.rs
+++ b/src/consul_configs.rs
@@ -5,78 +5,76 @@ use failure::Error;
 use serde_json;
 use std::{thread, time};
 
-pub fn wait_or_get(
-    chain: &str,
-    key: &str,
-    consul_url: &str,
-    consul_token: &str,
-    sidechain_name: &str,
-) -> Result<String, Error> {
-    let keyname = format!("chain/{}/{}", &sidechain_name, &chain);
-    let first = Box::new(true);
-    let json = consul_select(keyname.as_ref(), consul_url, consul_token, || {
-        if *first {
-            info!("chain for config not available in consul yet");
+pub struct ConsulConfig {
+    consul_url: String,
+    consul_token: String,
+    sidechain_name: String,
+}
+
+impl ConsulConfig {
+    pub fn new(consul_url: &str, consul_token: &str, sidechain_name: &str) -> Self {
+        Self {
+            consul_url: consul_url.to_string(),
+            consul_token: consul_token.to_string(),
+            sidechain_name: sidechain_name.to_string(),
         }
-    })?;
-    info!("chain for {:?} config available in consul now", chain);
-
-    if json[&key].is_u64() {
-        json[&key]
-            .as_u64()
-            .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
-                Ok(v.to_string())
-            })
-    } else {
-        json[&key]
-            .as_str()
-            .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
-                Ok(v.to_string())
-            })
     }
-}
 
-pub fn create_contract_abi(
-    contract_name: &str,
-    consul_url: &str,
-    consul_token: &str,
-    sidechain_name: &str,
-) -> Result<String, Error> {
-    let keyname = format!("chain/{}/{}", &sidechain_name, &contract_name);
-    let json = consul_select(keyname.as_ref(), consul_url, consul_token, || {
-        info!("chain for config not available in consul yet")
-    })?;
+    pub fn wait_or_get(&self, chain: &str, key: &str) -> Result<String, Error> {
+        let keyname = format!("chain/{}/{}", &self.sidechain_name, &chain);
+        let first = Box::new(true);
+        let json = self.consul_select(keyname.as_ref(), || {
+            if *first {
+                info!("chain for config not available in consul yet");
+            }
+        })?;
+        info!("chain for {:?} config available in consul now", chain);
 
-    Ok(
-        serde_json::ser::to_string(&json["abi"])
-            .or_else(|_| Err(OperationError::CouldNotGetConsulKey("abi".into())))?,
-    )
-}
-
-fn consul_select<F>(
-    keyname: &str,
-    consul_uri: &str,
-    consul_token: &str,
-    mut print_err: F,
-) -> Result<serde_json::Value, Error>
-where
-    F: FnMut(),
-{
-    let client = Client::new(consul_uri, consul_token);
-    let keystore = client.keystore;
-    let one_sec = time::Duration::from_secs(1);
-
-    loop {
-        if let Ok(result) = keystore.get_key(keyname.into()) {
-            let result_string = result.unwrap();
-            let config = decode(&result_string)?;
-            let new_config = String::from_utf8(config)?;
-            let json: serde_json::Value = serde_json::from_str(&new_config.as_str())?;
-            return Ok(json);
+        if json[&key].is_u64() {
+            json[&key]
+                .as_u64()
+                .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
+                    Ok(v.to_string())
+                })
         } else {
-            print_err();
-            thread::sleep(one_sec);
-            continue;
+            json[&key]
+                .as_str()
+                .map_or(Err(OperationError::CouldNotGetConsulKey(key.to_string()).into()), |v| {
+                    Ok(v.to_string())
+                })
+        }
+    }
+
+    pub fn create_contract_abi(&self, contract_name: &str) -> Result<String, Error> {
+        let keyname = format!("chain/{}/{}", &self.sidechain_name, contract_name);
+        let json = self.consul_select(keyname.as_ref(), || {
+            info!("chain for config not available in consul yet")
+        })?;
+
+        Ok(serde_json::ser::to_string(&json["abi"])
+            .or_else(|_| Err(OperationError::CouldNotGetConsulKey("abi".into())))?)
+    }
+
+    fn consul_select<F>(&self, keyname: &str, mut print_err: F) -> Result<serde_json::Value, Error>
+    where
+        F: FnMut(),
+    {
+        let client = Client::new(&self.consul_url, &self.consul_token);
+        let keystore = client.keystore;
+        let one_sec = time::Duration::from_secs(1);
+
+        loop {
+            if let Ok(result) = keystore.get_key(keyname.into()) {
+                let result_string = result.unwrap();
+                let config = decode(&result_string)?;
+                let new_config = String::from_utf8(config)?;
+                let json: serde_json::Value = serde_json::from_str(&new_config.as_str())?;
+                return Ok(json);
+            } else {
+                print_err();
+                thread::sleep(one_sec);
+                continue;
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,26 @@ fn run(
                 .and_then(move |side_nonce| {
                     let mut _home_nonce = AtomicUsize::new(home_nonce.as_u64() as usize);
                     let mut _side_nonce = AtomicUsize::new(side_nonce.as_u64() as usize);
+                    let home_chain_id = consul_configs::wait_or_get(
+                        "homechain",
+                        "chain_id",
+                        &settings.relay.consul,
+                        &settings.relay.consul_token,
+                        &settings.relay.community,
+                    )
+                    .map_err(|e| e.to_string())?
+                    .parse::<u64>()
+                    .map_err(|e| e.to_string())?;
+                    let side_chain_id = consul_configs::wait_or_get(
+                        "sidechain",
+                        "chain_id",
+                        &settings.relay.consul,
+                        &settings.relay.consul_token,
+                        &settings.relay.community,
+                    )
+                    .map_err(|e| e.to_string())?
+                    .parse::<u64>()
+                    .map_err(|e| e.to_string())?;
 
                     let relay = Relay::new(
                         Network::homechain(
@@ -183,7 +203,7 @@ fn run(
                             settings.relay.homechain.free,
                             settings.relay.confirmations,
                             settings.relay.sidechain.interval,
-                            settings.relay.homechain.chain_id,
+                            home_chain_id,
                             &settings.relay.keydir,
                             &settings.relay.password,
                             _home_nonce,
@@ -226,7 +246,7 @@ fn run(
                             settings.relay.confirmations,
                             settings.relay.anchor_frequency,
                             settings.relay.sidechain.interval,
-                            settings.relay.sidechain.chain_id,
+                            side_chain_id,
                             &settings.relay.keydir,
                             &settings.relay.password,
                             _side_nonce,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -60,8 +60,6 @@ pub struct Network {
     pub free: bool,
     /// seconds between checks for missed transactions
     pub interval: u64,
-    /// Chain id for an Ethereum client
-    pub chain_id: u64,
 }
 
 impl Settings {


### PR DESCRIPTION
Changing to use `chain_id` from consul which is preferred to setting it in the config.toml - should make deploying a bit easier.