### PR TITLE
Fix SendTransaction future

### DIFF
--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -75,7 +75,7 @@ impl<T: DuplexTransport + 'static> Future for HandleAnchors<T> {
         loop {
             let anchor = try_ready!(self.stream.poll());
             if let Some(a) = anchor {
-                self.handle.spawn(a.process(&self.target))
+                self.handle.spawn(a.process(&self.target));
             }
         }
     }

--- a/src/consul_configs.rs
+++ b/src/consul_configs.rs
@@ -82,13 +82,13 @@ impl ConsulConfig {
                     let val = &contract_addresses[chain];
 
                     if &json != val {
-                        info!("Config change detected, exiting...");
+                        info!("config change detected, exiting...");
                         process::exit(1);
                     } else {
                         thread::sleep(one_sec);
                     }
                 } else {
-                    info!("Config change detected, exiting...");
+                    info!("config change detected, exiting...");
                     process::exit(1);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,13 +239,13 @@ fn run(
                 })
                 .or_else(|e| {
                     error!("{:?}", e);
-                    error!("Error getting transaction count on sidechain. Are you connected to geth?");
+                    error!("error getting transaction count on sidechain. Are you connected to geth?");
                     Ok(())
                 })
         })
         .or_else(|e| {
             error!("{:?}", e);
-            error!("Error getting transaction count on homechain. Are you connected to geth?");
+            error!("error getting transaction count on homechain. Are you connected to geth?");
             Ok(())
         })
 }

--- a/src/missed_transfer.rs
+++ b/src/missed_transfer.rs
@@ -53,11 +53,11 @@ impl FindMissedTransfers {
                                     block.as_u64() - confirmations - LOOKBACK_RANGE
                                 };
                                 if block.as_u64() < confirmations + LOOKBACK_LEEWAY {
-                                    return Err(web3::Error::from_kind(web3::ErrorKind::Msg("Not enough blocks to look back".to_string())));
+                                    return Err(web3::Error::from_kind(web3::ErrorKind::Msg("Not enough blocks to check".to_string())));
                                 }
                                 let to = block.as_u64() - confirmations - LOOKBACK_LEEWAY;
                                 info!(
-                                    "Looking for logs between {} and {} on {:?}",
+                                    "checking logs between {} and {} on {:?}",
                                     from,
                                     to,
                                     network_type,
@@ -79,7 +79,7 @@ impl FindMissedTransfers {
                                     let web3 = web3.clone();
                                     let handle = handle.clone();
                                     info!(
-                                        "Found {} transfers on {:?}",
+                                        "found {} transfers on {:?}",
                                         logs.len(),
                                         network_type
                                     );
@@ -222,7 +222,7 @@ impl HandleMissedTransfers {
                     Ok(())
                 })
                 .or_else(move |e| {
-                    error!("Error searching for and approving missed transfers: {:?}", e);
+                    error!("error searching for and approving missed transfers: {:?}", e);
                     Ok(())
                 })
         });

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -121,7 +121,7 @@ impl DuplexTransport for MockTransport {
     fn subscribe(&self, id: &SubscriptionId) -> Self::NotificationStream {
         let (tx, rx) = mpsc::unbounded();
         if self.subscriptions.lock().insert(id.clone(), tx).is_some() {
-            warn!("Replacing subscription with id {:?}", id);
+            warn!("replacing subscription with id {:?}", id);
         }
         Box::new(rx.map_err(|()| ErrorKind::Transport("No data available".into()).into()))
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -194,7 +194,10 @@ where
                     let send_future = self
                         .target
                         .relay
-                        .send_raw_call_with_confirmations(rlp_stream.as_raw().into(), self.target.confirmations as usize)
+                        .send_raw_call_with_confirmations(
+                            rlp_stream.as_raw().into(),
+                            self.target.confirmations as usize,
+                        )
                         .map_err(move |e| {
                             error!("error completing {} transaction: {}", function, e);
                         });

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -102,7 +102,7 @@ impl<T: DuplexTransport + 'static> Future for HandleTransfers<T> {
         loop {
             let transfer = try_ready!(self.stream.poll());
             if let Some(t) = transfer {
-                self.handle.spawn(t.approve_withdrawal(&self.target))
+                self.handle.spawn(t.approve_withdrawal(&self.target));
             }
         }
     }

--- a/src/withdrawal.rs
+++ b/src/withdrawal.rs
@@ -96,12 +96,12 @@ impl Future for GetWithdrawal {
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let withdrawal = try_ready!(self.future.poll());
         if withdrawal.destination == Address::zero() && withdrawal.amount.as_u64() == 0 {
-            info!("Found transfer that was never approved");
+            info!("found transfer that was never approved");
             Ok(Async::Ready(withdrawal))
         } else if withdrawal.destination == self.transfer.destination && withdrawal.amount == self.transfer.amount {
             Ok(Async::Ready(withdrawal))
         } else {
-            error!("Withdrawal from contract did not match transfer");
+            error!("withdrawal from contract did not match transfer");
             Err(())
         }
     }


### PR DESCRIPTION
The future was wrong, returning `Ok(Async::NotReady)` without park handling caused issues. 

Instead, we use a loop and let try_ready do all the work.

Also, cleaned up some logs

Closes #48 