### PR TITLE
removing multi-stage to use --cache-from in a more efficient way

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,4 @@ RUN find ./src -type f -exec touch {} \; \
 COPY ./docker/config.toml ./config.toml
 COPY ./docker/keyfiles /keyfiles
 
-COPY ./lint.sh ./test.sh ./coverage.sh ./
-
 CMD ["polyswarm-relay", "--config", "config.toml"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,9 @@ RUN find ./src -type f -exec touch {} \; \
 
 # These are being copied here due to default configurations in "orchestration"
 # TODO: "orchestration" should not provide explicit or absolte paths
-COPY ./docker/config.toml /config.toml
+COPY ./docker/config.toml ./config.toml
 COPY ./docker/keyfiles /keyfiles
+
+COPY ./lint.sh ./test.sh ./coverage.sh ./
 
 CMD ["polyswarm-relay", "--config", "config.toml"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,17 @@ LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_VERSION 0.2.7
+ENV DOCKERIZE_VERSION v0.6.1
 
 RUN wget https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz \
     && tar -xzvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz \
     && mv sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache /usr/local/bin \
     && rm -rf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl* \
-    && USER=root cargo new --bin polyswarm-relay
+    && USER=root cargo new --bin polyswarm-relay \
+    # Keep dockerize for now, this should probably go away in future versions
+    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /polyswarm-relay
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,19 @@
-FROM rust
+FROM rust:1.31.1
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
+ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_VERSION 0.2.7
+
 RUN wget https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz \
     && tar -xzvf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz \
     && mv sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache /usr/local/bin \
-    && rm -rf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl*
+    && rm -rf sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl* \
+    && USER=root cargo new --bin polyswarm-relay
 
-ENV RUSTC_WRAPPER=sccache
-
-# These potentially contain secrets from CI but are included in intermediate
-# image so is fine
-ARG SCCACHE_BUCKET
-ENV SCCACHE_BUCET=$SCCACHE_BUCKET
-ARG AWS_ACCESS_KEY_ID
-ENV AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
-ARG AWS_SECRET_ACCESS_KEY
-ENV AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-
-# Create a new empty shell project
-RUN USER=root cargo new --bin polyswarm-relay
 WORKDIR /polyswarm-relay
 
-# Copy over your manifests
-COPY ./Cargo.lock ./Cargo.lock
-COPY ./Cargo.toml ./Cargo.toml
+## Copy over your manifests
+COPY Cargo.lock Cargo.toml ./
 
 # This build step will cache your dependencies
 RUN cargo build --release \
@@ -33,22 +22,10 @@ RUN cargo build --release \
 RUN rm -r src/
 COPY ./src ./src
 
-RUN find ./src -type f -exec touch {} \; && \
-    cargo build --release
+RUN find ./src -type f -exec touch {} \; \
+    && cargo build --release \
+    && cp /polyswarm-relay/target/release/polyswarm-relay /usr/local/bin
 
-# Final image
-FROM ubuntu:bionic
-
-RUN apt-get update && apt-get install -y \
-        wget \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-COPY --from=0 /polyswarm-relay/target/release/polyswarm-relay /usr/local/bin
 COPY ./docker/config.toml ./config.toml
 COPY ./docker/keyfiles ./keyfiles
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,9 @@ RUN find ./src -type f -exec touch {} \; \
     && cargo build --release \
     && cp /polyswarm-relay/target/release/polyswarm-relay /usr/local/bin
 
-COPY ./docker/config.toml ./config.toml
-COPY ./docker/keyfiles ./keyfiles
+# These are being copied here due to default configurations in "orchestration"
+# TODO: "orchestration" should not provide explicit or absolte paths
+COPY ./docker/config.toml /config.toml
+COPY ./docker/keyfiles /keyfiles
 
 CMD ["polyswarm-relay", "--config", "config.toml"]


### PR DESCRIPTION
Multi-stage builds prevent cache from being used for new builds. For instance, when running CI, we would probably do

```
docker pull relay:lastest
docker build --cache-from=relay:lastest -t relay:new-image .
```

Since we are pushing only the last image, the first images are not in the cache at this point, and need to be rebuilt. Since we can achieve the same functionality with a single stage image, I modified it in order to use `rust:1.31.1` as the base image (which is also the version being used in `.gitlab-ci.yml` for testing --- we should probably look into ways of getting this version from a single place to have a parity between tests and the image that is being built).

Related issues are:

https://github.com/moby/moby/issues/34715
https://github.com/moby/moby/issues/33002