### PR TITLE
Enabling branch-based multi-project merge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,14 +18,23 @@ variables:
 # Build Stage (jobs inside a stage run in parallel)
 ###############################################################
 
-build:
+build-linux:
   stage: build
   tags:
     - kube
   script:
-    - docker pull $REPO_URL/$BASE_IMAGE_NAME:latest || true
-    - docker build -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA -f docker/Dockerfile --cache-from=$REPO_URL/$BASE_IMAGE_NAME:latest .
-    - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+     # try to download a cache image
+     - docker pull $REPO_URL/$BASE_IMAGE_NAME:latest || true
+     # explicitly pull the latest version of the dependant image
+     - docker pull rust:1.36.0
+     - docker build
+       -f docker/Dockerfile
+       -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+       -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
+       --cache-from=$REPO_URL/$BASE_IMAGE_NAME:latest
+       .
+     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
 
 ###############################################################
 # Test Stage
@@ -67,7 +76,7 @@ e2e:
   tags:
     - kube
   script:
-    - pip install $END_TO_END_LIB
+    - pip install $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install $END_TO_END_LIB
     - e2e init
     - e2e run
 


### PR DESCRIPTION
This tags the image with the branch name and uses e2e from the branch if available as well. e2e checks for alike branches when pulling images.