### PR TITLE
Withdraw all NCT from a sidechain that is flushed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "polyswarm-relay"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "actix-web 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polyswarm-relay"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["PolySwarm Developers <info@polyswarm.io>"]
 
 [dependencies]

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -26,7 +26,7 @@ impl Anchor {
     /// # Arguments
     ///
     /// * `target` - Network to post the anchor
-    fn process<T: DuplexTransport + 'static>(&self, target: &Rc<Network<T>>) -> SendTransaction<T, Self> {
+    fn process<T: DuplexTransport + 'static>(&self, target: &Network<T>) -> SendTransaction<T, Self> {
         info!("anchoring block {} to {:?}", self, target.network_type);
         SendTransaction::new(target, "anchor", self, target.retries)
     }
@@ -49,7 +49,7 @@ impl fmt::Display for Anchor {
 
 /// Future to handle the Stream of anchors & post them to the chain
 pub struct HandleAnchors<T: DuplexTransport + 'static> {
-    target: Rc<Network<T>>,
+    target: Network<T>,
     stream: FindAnchors,
     handle: reactor::Handle,
 }
@@ -62,7 +62,7 @@ impl<T: DuplexTransport + 'static> HandleAnchors<T> {
     /// * `source` - Network where the block headers are captured
     /// * `target` - Network where the headers will be anchored
     /// * `handle` - Handle to spawn new futures
-    pub fn new(source: &Network<T>, target: &Rc<Network<T>>, handle: &reactor::Handle) -> Self {
+    pub fn new(source: &Network<T>, target: &Network<T>, handle: &reactor::Handle) -> Self {
         let handle = handle.clone();
         let target = target.clone();
         let stream = FindAnchors::new(source, &handle);

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -1,6 +1,5 @@
 use ethabi::Token;
 use std::fmt;
-use std::rc::Rc;
 use tokio_core::reactor;
 use web3::contract::tokens::Tokenize;
 use web3::futures::prelude::*;

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -25,9 +25,9 @@ impl Anchor {
     /// # Arguments
     ///
     /// * `target` - Network to post the anchor
-    fn process<T: DuplexTransport + 'static>(&self, target: &Network<T>) -> SendTransaction<T, Self> {
+    fn process<T: DuplexTransport + 'static>(&self, target: &Network<T>) -> Box<Future<Item = (), Error = ()>> {
         info!("anchoring block {} to {:?}", self, target.network_type);
-        SendTransaction::new(target, "anchor", self, target.retries)
+        Box::new(SendTransaction::new(target, "anchor", self, target.retries).or_else(|_| Ok(())))
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,6 +41,9 @@ pub enum EndpointError {
     #[fail(display = "unable to get relay status.")]
     UnableToGetStatus,
 
+    #[fail(display = "unable to get nectar balances.")]
+    UnableToGetBalances,
+
     #[fail(display = "timeout")]
     Timeout,
 }
@@ -52,6 +55,7 @@ impl ResponseError for EndpointError {
             EndpointError::BadTransactionHash(_) => HttpResponse::new(http::StatusCode::BAD_REQUEST),
             EndpointError::UnableToSend => HttpResponse::new(http::StatusCode::INTERNAL_SERVER_ERROR),
             EndpointError::UnableToGetStatus => HttpResponse::new(http::StatusCode::INTERNAL_SERVER_ERROR),
+            EndpointError::UnableToGetBalances => HttpResponse::new(http::StatusCode::INTERNAL_SERVER_ERROR),
             EndpointError::Timeout => HttpResponse::new(http::StatusCode::REQUEST_TIMEOUT),
         }
     }

--- a/src/eth/contracts.rs
+++ b/src/eth/contracts.rs
@@ -1,5 +1,3 @@
-use web3::types::H256;
-
 /// Event signature for ERC20 transfers, equals sha3("Transfer(address,address,uint256)")
 pub const TRANSFER_EVENT_SIGNATURE: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 /// Event signature for ERC20 transfers, equals sha3("Flush()")

--- a/src/eth/contracts.rs
+++ b/src/eth/contracts.rs
@@ -1,3 +1,5 @@
+use web3::types::H256;
+
 /// Event signature for ERC20 transfers, equals sha3("Transfer(address,address,uint256)")
 pub const TRANSFER_EVENT_SIGNATURE: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 /// Event signature for ERC20 transfers, equals sha3("Flush()")

--- a/src/eth/contracts.rs
+++ b/src/eth/contracts.rs
@@ -1,2 +1,4 @@
 /// Event signature for ERC20 transfers, equals sha3("Transfer(address,address,uint256)")
 pub const TRANSFER_EVENT_SIGNATURE: &str = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+/// Event signature for ERC20 transfers, equals sha3("Flush()")
+pub const FLUSH_EVENT_SIGNATURE: &str = "0x0c0adcef1ca5bbf843985f21efffb63e6817af6b8dd1f00e7344a8ad05ab2d51";

--- a/src/eth/transaction.rs
+++ b/src/eth/transaction.rs
@@ -1,22 +1,16 @@
 use ethcore_transaction::{Action, Transaction as RawTransactionRequest};
 use ethstore::accounts_dir::RootDiskDirectory;
 use ethstore::{EthStore, SimpleSecretStore, StoreAccountRef};
-use extensions::removed::{CancelRemoved, ExitOnLogRemoved};
 use rlp::{Encodable, RlpStream};
-use std::rc::Rc;
 use std::sync::atomic::Ordering;
-use std::time;
-use web3::confirm::{wait_for_transaction_confirmation, SendTransactionWithConfirmation};
 use web3::contract::tokens::Tokenize;
-use web3::futures::future::Either;
 use web3::futures::prelude::*;
 use web3::futures::try_ready;
-use web3::types::{Address, TransactionReceipt, H256, U256};
+use web3::types::{TransactionReceipt, U256};
 use web3::DuplexTransport;
 
 use super::errors::OperationError;
 use super::relay::Network;
-use relay::NetworkType;
 
 pub enum TransactionState<T, P>
 where

--- a/src/eth/transaction.rs
+++ b/src/eth/transaction.rs
@@ -220,7 +220,8 @@ where
                                     if result == 1.into() {
                                         info!("{} on {:?} successful: {:?}", function, network_type, receipt);
                                     } else {
-                                        warn!("{} on {:?} failed: {:?}", function, network_type, receipt);
+                                        error!("{} on {:?} failed: {:?}", function, network_type, receipt);
+                                        return Err(());
                                     }
                                 }
                                 None => {

--- a/src/extensions/removed.rs
+++ b/src/extensions/removed.rs
@@ -198,5 +198,4 @@ mod tests {
         // assert
         assert_eq!(result, Err(()))
     }
-
 }

--- a/src/extensions/removed.rs
+++ b/src/extensions/removed.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use web3::futures::prelude::*;
 use web3::types::H256;
 use web3::DuplexTransport;

--- a/src/extensions/removed.rs
+++ b/src/extensions/removed.rs
@@ -9,7 +9,7 @@ pub struct ExitOnLogRemoved<T, I, E>
 where
     T: DuplexTransport + 'static,
 {
-    target: Rc<Network<T>>,
+    target: Network<T>,
     tx_hash: H256,
     future: Box<Future<Item = I, Error = E>>,
 }
@@ -18,9 +18,9 @@ impl<T, I, E> ExitOnLogRemoved<T, I, E>
 where
     T: DuplexTransport + 'static,
 {
-    pub fn new(target: Rc<Network<T>>, tx_hash: H256, future: Box<Future<Item = I, Error = E>>) -> Self {
+    pub fn new(target: &Network<T>, tx_hash: H256, future: Box<Future<Item = I, Error = E>>) -> Self {
         ExitOnLogRemoved {
-            target,
+            target: target.clone(),
             tx_hash,
             future,
         }
@@ -61,7 +61,7 @@ where
     /// * `self` - Existing Future that this is added to. Consumes self.
     /// * `target` - Target network to check against
     /// * `tx_hash` - Tx hash to check for removal
-    fn cancel_removed(self, target: &Rc<Network<T>>, tx_hash: H256) -> ExitOnLogRemoved<T, I, E>;
+    fn cancel_removed(self, target: &Network<T>, tx_hash: H256) -> ExitOnLogRemoved<T, I, E>;
 }
 
 #[cfg(test)]
@@ -103,7 +103,7 @@ mod tests {
     where
         T: DuplexTransport + 'static,
     {
-        fn cancel_removed(self, target: &Rc<Network<T>>, tx_hash: H256) -> ExitOnLogRemoved<T, (), ()> {
+        fn cancel_removed(self, target: &Network<T>, tx_hash: H256) -> ExitOnLogRemoved<T, (), ()> {
             ExitOnLogRemoved::<T, (), ()>::new(target.clone(), tx_hash, Box::new(self))
         }
     }

--- a/src/extensions/removed.rs
+++ b/src/extensions/removed.rs
@@ -104,7 +104,7 @@ mod tests {
         T: DuplexTransport + 'static,
     {
         fn cancel_removed(self, target: &Network<T>, tx_hash: H256) -> ExitOnLogRemoved<T, (), ()> {
-            ExitOnLogRemoved::<T, (), ()>::new(target.clone(), tx_hash, Box::new(self))
+            ExitOnLogRemoved::<T, (), ()>::new(target, tx_hash, Box::new(self))
         }
     }
 
@@ -114,9 +114,9 @@ mod tests {
         let mut eloop = tokio_core::reactor::Core::new().unwrap();
         let handle = eloop.handle();
         let mock = MockTransport::new();
-        let target = Rc::new(mock.new_network(NetworkType::Home).unwrap());
+        let target = mock.new_network(NetworkType::Home).unwrap();
         let future = ExitOnLogRemoved::<MockTransport, (), std::io::Error>::new(
-            target.clone(),
+            &target,
             H256::zero(),
             Box::new(reactor::Timeout::new(Duration::from_secs(1), &handle).unwrap()),
         );
@@ -137,9 +137,9 @@ mod tests {
         let mut eloop = tokio_core::reactor::Core::new().unwrap();
         let handle = eloop.handle();
         let mock = MockTransport::new();
-        let target = Rc::new(mock.new_network(NetworkType::Home).unwrap());
+        let target = mock.new_network(NetworkType::Home).unwrap();
         let future = ExitOnLogRemoved::<MockTransport, (), std::io::Error>::new(
-            target.clone(),
+            &target,
             H256::zero(),
             Box::new(reactor::Timeout::new(Duration::from_secs(1), &handle).unwrap()),
         );
@@ -155,7 +155,7 @@ mod tests {
         let mut eloop = tokio_core::reactor::Core::new().unwrap();
         let handle = eloop.handle();
         let mock = MockTransport::new();
-        let target = Rc::new(mock.new_network(NetworkType::Home).unwrap());
+        let target = mock.new_network(NetworkType::Home).unwrap();
         let future = TestCheckRemoved::new(&handle).cancel_removed(&target, H256::zero());
         // act
         target
@@ -174,7 +174,7 @@ mod tests {
         let mut eloop = tokio_core::reactor::Core::new().unwrap();
         let handle = eloop.handle();
         let mock = MockTransport::new();
-        let target = Rc::new(mock.new_network(NetworkType::Home).unwrap());
+        let target = mock.new_network(NetworkType::Home).unwrap();
         let future = TestCheckRemoved::new(&handle).cancel_removed(&target, H256::zero());
 
         // act
@@ -188,7 +188,7 @@ mod tests {
         // arrange
         let mut eloop = tokio_core::reactor::Core::new().unwrap();
         let mock = MockTransport::new();
-        let target = Rc::new(mock.new_network(NetworkType::Home).unwrap());
+        let target = mock.new_network(NetworkType::Home).unwrap();
         let future = TestCheckRemoved {
             inner: Box::new(web3::futures::future::err(())),
         }

--- a/src/extensions/timeout.rs
+++ b/src/extensions/timeout.rs
@@ -7,8 +7,8 @@ use web3::futures::try_ready;
 use web3::{DuplexTransport, ErrorKind};
 
 /// Enum for the two stages of subscribing to a timeout stream
-/// Subscribing is holds future that returns a TimeoutStream
-/// Subscribed is holds a TimeoutStream
+/// Subscribing holds a future that returns a TimeoutStream
+/// Subscribed holds a TimeoutStream
 pub enum SubscriptionState<T, I>
 where
     T: DuplexTransport + 'static,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ extern crate ethkey;
 extern crate ethstore;
 extern crate rlp;
 extern crate serde;
+extern crate tokio;
 
 pub mod anchors;
 pub mod errors;
@@ -74,7 +75,7 @@ fn main() -> Result<(), Error> {
 
     // Parse options
     let matches = App::new("Polyswarm Relay")
-        .version("0.1.1")
+        .version("1.1.0")
         .author("PolySwarm Developers <info@polyswarm.io>")
         .about("Relays ERC20 tokens between two different networks.")
         .arg(

--- a/src/mock/transport.rs
+++ b/src/mock/transport.rs
@@ -374,5 +374,4 @@ mod tests {
         let headers = eloop.run(stream).unwrap();
         assert_eq!(value, *headers.get(0).unwrap());
     }
-
 }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -335,7 +335,7 @@ impl<T: DuplexTransport + 'static> Network<T> {
             .topics(Some(vec![FLUSH_EVENT_SIGNATURE.into()]), None, None, None)
             .build();
         // This on just watches right inside, no tx to send to
-        let watch = WatchLiveLogs::new(self, target, &filter, &tx, handle)
+        let watch = WatchLiveLogs::new(self, &filter, &tx, handle)
             .map_err(move |e| error!("error watching transaction logs {:?}", e));
         // We do this in a separately spawned task because we have to wait 20 blocks per
         handle.spawn(watch);
@@ -360,7 +360,7 @@ impl<T: DuplexTransport + 'static> Network<T> {
                 None,
             )
             .build();
-        let watch = WatchLiveLogs::new(self, target, &filter, &tx, handle)
+        let watch = WatchLiveLogs::new(self, &filter, &tx, handle)
             .map_err(move |e| error!("error watching transaction logs {:?}", e));
         // We do this in a separately spawned task because we have to wait 20 blocks per
         handle.spawn(watch);
@@ -434,7 +434,6 @@ impl<T: DuplexTransport + 'static> Network<T> {
         }
         .map_err(move |_| {
             error!("error checking transaction on {:?}", network_type);
-            ()
         });
         Box::new(future)
     }

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -19,11 +19,11 @@ use super::eth::contracts::{FLUSH_EVENT_SIGNATURE, TRANSFER_EVENT_SIGNATURE};
 use super::eth::utils::clean_0x;
 use super::extensions::removed::{CancelRemoved, ExitOnLogRemoved};
 use super::server::{HandleRequests, RequestType};
+use super::transfers::flush::CheckForPastFlush;
 use super::transfers::flush::ProcessFlush;
 use super::transfers::live::ProcessTransfer;
 use super::transfers::live::WatchLiveLogs;
 use super::transfers::past::RecheckPastTransferLogs;
-use transfers::flush::CheckForPastFlush;
 
 const FREE_GAS_PRICE: u64 = 0;
 const GAS_LIMIT: u64 = 200_000;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -23,6 +23,7 @@ use super::transfers::flush::ProcessFlush;
 use super::transfers::live::ProcessTransfer;
 use super::transfers::live::WatchLiveLogs;
 use super::transfers::past::RecheckPastTransferLogs;
+use transfers::flush::CheckForPastFlush;
 
 const FREE_GAS_PRICE: u64 = 0;
 const GAS_LIMIT: u64 = 200_000;
@@ -339,6 +340,8 @@ impl<T: DuplexTransport + 'static> Network<T> {
             .map_err(move |e| error!("error watching transaction logs {:?}", e));
         // We do this in a separately spawned task because we have to wait 20 blocks per
         handle.spawn(watch);
+        let check_existing = CheckForPastFlush::new(self, &tx);
+        handle.spawn(check_existing);
         ProcessFlush::new(self, target, rx)
     }
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -14,7 +14,7 @@ use web3::{DuplexTransport, Web3};
 use super::anchors::anchor::HandleAnchors;
 use super::errors::OperationError;
 use super::eth::utils::clean_0x;
-use super::server::endpoint::{HandleRequests, RequestType};
+use super::server::{HandleRequests, RequestType};
 use super::transfers::live::WatchLiveTransfers;
 use super::transfers::past::RecheckPastTransferLogs;
 use transfers::live::ProcessTransfer;
@@ -42,7 +42,7 @@ impl<T: DuplexTransport + 'static> Relay<T> {
         }
     }
 
-    fn handle_requests(&self, rx: mpsc::UnboundedReceiver<RequestType>, handle: &reactor::Handle) -> HandleRequests {
+    fn handle_requests(&self, rx: mpsc::UnboundedReceiver<RequestType>, handle: &reactor::Handle) -> HandleRequests<T> {
         HandleRequests::new(&self.homechain, &self.sidechain, rx, handle)
     }
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -335,7 +335,7 @@ impl<T: DuplexTransport + 'static> Network<T> {
             .map_err(move |e| error!("error watching transaction logs {:?}", e));
         // We do this in a separately spawned task because we have to wait 20 blocks per
         handle.spawn(watch);
-        ProcessFlush::new(self, target, rx, handle)
+        ProcessFlush::new(self, target, rx)
     }
 
     /// Returns a ProcessTransfer Future for this chain.

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -1,6 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::thread;
+use std::time::Duration;
 use web3::futures::future;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
@@ -26,16 +27,18 @@ pub enum RequestType {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BalanceResponse {
+    duration: u64,
     balances: HashMap<Address, String>,
 }
 
 impl BalanceResponse {
-    pub fn new(balances: &HashMap<Address, U256>) -> Self {
+    pub fn new(duration: &Duration, balances: &HashMap<Address, U256>) -> Self {
         let mut converted: HashMap<Address, String> = HashMap::new();
         for (key, value) in balances.iter() {
             converted.entry(key.clone()).or_insert(BalanceResponse::convert(*value));
         }
         BalanceResponse {
+            duration: duration.as_secs(),
             balances: converted,
         }
     }

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -105,18 +105,16 @@ impl Endpoint {
                         let tx = status_tx.clone();
                         status(&tx)
                     })))
+                    .service(
+                        web::resource("/{chain}/balances").route(web::get().to(move |info: web::Path<String>| {
+                            let tx = balance_tx.clone();
+                            balances(&tx, &info)
+                    })))
                     .service(web::resource("/{chain}/{tx_hash}").route(web::post().to(
                         move |info: web::Path<(String, String)>| {
                             let tx = hash_tx.clone();
                             search(&tx, &info)
-                        },
-                    )))
-                    .service(
-                        web::resource("/{chain}/balances").route(web::get().to(move |info: String| {
-                            let tx = balance_tx.clone();
-                            balances(&tx, &info)
-                        })),
-                    )
+                    })))
             })
             .bind(format!("0.0.0.0:{}", port))
             .unwrap()

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -26,14 +26,22 @@ pub enum RequestType {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BalanceResponse {
-    balances: HashMap<Address, U256>,
+    balances: HashMap<Address, String>,
 }
 
 impl BalanceResponse {
     pub fn new(balances: &HashMap<Address, U256>) -> Self {
-        BalanceResponse {
-            balances: balances.clone(),
+        let mut converted: HashMap<Address, String> = HashMap::new();
+        for (key, value) in balances.iter() {
+            converted.entry(key.clone()).or_insert(BalanceResponse::convert(*value));
         }
+        BalanceResponse {
+            balances: converted,
+        }
+    }
+
+    fn convert(balance: U256) -> String {
+        format!("{}", balance).to_string()
     }
 }
 

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -109,12 +109,14 @@ impl Endpoint {
                         web::resource("/{chain}/balances").route(web::get().to(move |info: web::Path<String>| {
                             let tx = balance_tx.clone();
                             balances(&tx, &info)
-                    })))
+                        })),
+                    )
                     .service(web::resource("/{chain}/{tx_hash}").route(web::post().to(
                         move |info: web::Path<(String, String)>| {
                             let tx = hash_tx.clone();
                             search(&tx, &info)
-                    })))
+                        },
+                    )))
             })
             .bind(format!("0.0.0.0:{}", port))
             .unwrap()

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -206,14 +206,14 @@ fn search(
 /// * `info` - Tuple of two strings. The chain and tx hash.
 fn balances(
     tx: &mpsc::UnboundedSender<RequestType>,
-    info: &String,
+    info: &str,
 ) -> Box<Future<Item = HttpResponse, Error = EndpointError>> {
     let chain = if info.to_uppercase() == "HOME" {
         NetworkType::Home
     } else if info.to_uppercase() == "SIDE" {
         NetworkType::Side
     } else {
-        return Box::new(future::err(EndpointError::BadChain(info.clone())));
+        return Box::new(future::err(EndpointError::BadChain(info.to_string())));
     };
 
     let (balance_tx, balance_rx) = mpsc::unbounded();

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -1,19 +1,16 @@
+use actix_web::http::StatusCode;
+use actix_web::{middleware, web, App, HttpResponse, HttpServer};
 use serde_derive::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::thread;
-use std::time::Duration;
 use web3::futures::future;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
-use web3::types::{Address, H256, U256};
-
-use actix_web::http::StatusCode;
-use actix_web::{middleware, web, App, HttpResponse, HttpServer};
+use web3::types::{H256, U256};
 
 use super::errors::EndpointError;
 use super::eth::utils;
 use super::relay::NetworkType;
-use std::collections::HashMap;
 
 pub const HOME: &str = "HOME";
 pub const SIDE: &str = "SIDE";
@@ -85,7 +82,6 @@ impl Endpoint {
             HttpServer::new(move || {
                 let status_tx = self.tx.clone();
                 let hash_tx = self.tx.clone();
-                let balance_tx = self.tx.clone();
                 App::new()
                     .wrap(middleware::Logger::default())
                     .service(web::resource("/status").route(web::get().to(move || {

--- a/src/server/endpoint.rs
+++ b/src/server/endpoint.rs
@@ -1,28 +1,18 @@
-use ethabi::Token;
 use serde_derive::{Deserialize, Serialize};
-use std::rc::Rc;
 use std::str::FromStr;
 use std::thread;
-use tokio_core::reactor;
-use web3::contract;
-use web3::contract::tokens::{Detokenize, Tokenize};
-use web3::contract::Options;
 use web3::futures::future;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
-use web3::futures::try_ready;
-use web3::types::{Address, BlockNumber, TransactionReceipt, H256, U256};
-use web3::DuplexTransport;
+use web3::types::{Address, H256, U256};
 
 use actix_web::http::StatusCode;
 use actix_web::{middleware, web, App, HttpResponse, HttpServer};
 
 use super::errors::EndpointError;
-use super::eth::contracts::TRANSFER_EVENT_SIGNATURE;
 use super::eth::utils;
-use super::relay::{Network, NetworkType};
-use super::transfers::past::ValidateAndApproveTransfer;
-use super::transfers::transfer::Transfer;
+use super::relay::NetworkType;
+use std::collections::HashMap;
 
 pub const HOME: &str = "HOME";
 pub const SIDE: &str = "SIDE";
@@ -31,6 +21,20 @@ pub const SIDE: &str = "SIDE";
 pub enum RequestType {
     Hash(NetworkType, H256),
     Status(mpsc::UnboundedSender<Result<StatusResponse, ()>>),
+    Balance(NetworkType, mpsc::UnboundedSender<Result<BalanceResponse, ()>>),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BalanceResponse {
+    balances: HashMap<Address, U256>,
+}
+
+impl BalanceResponse {
+    pub fn new(balances: &HashMap<Address, U256>) -> Self {
+        BalanceResponse {
+            balances: balances.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -94,6 +98,7 @@ impl Endpoint {
             HttpServer::new(move || {
                 let status_tx = self.tx.clone();
                 let hash_tx = self.tx.clone();
+                let balance_tx = self.tx.clone();
                 App::new()
                     .wrap(middleware::Logger::default())
                     .service(web::resource("/status").route(web::get().to(move || {
@@ -106,6 +111,12 @@ impl Endpoint {
                             search(&tx, &info)
                         },
                     )))
+                    .service(
+                        web::resource("/{chain}/balances").route(web::get().to(move |info: String| {
+                            let tx = balance_tx.clone();
+                            balances(&tx, &info)
+                        })),
+                    )
             })
             .bind(format!("0.0.0.0:{}", port))
             .unwrap()
@@ -189,331 +200,58 @@ fn search(
     Ok(HttpResponse::new(StatusCode::OK))
 }
 
-/// Future to handle the Stream of missed transfers by checking them, and approving them
-pub struct HandleRequests {
-    future: Box<Future<Item = (), Error = ()>>,
-}
+/// Return an HttpResponse with the list of current balances for all non-contract token holders
+///
+/// # Arguments
+///
+/// * `tx` - Sender to report new requests
+/// * `info` - Tuple of two strings. The chain and tx hash.
+fn balances(
+    tx: &mpsc::UnboundedSender<RequestType>,
+    info: &String,
+) -> Box<Future<Item = HttpResponse, Error = EndpointError>> {
+    let chain = if info.to_uppercase() == "HOME" {
+        NetworkType::Home
+    } else if info.to_uppercase() == "SIDE" {
+        NetworkType::Side
+    } else {
+        return Box::new(future::err(EndpointError::BadChain(info.clone())));
+    };
 
-impl HandleRequests {
-    /// Returns a newly created HandleMissedTransfers Future
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - Network where the missed transfers are captured
-    /// * `target` - Network where the transfer will be approved for a withdrawal
-    /// * `rx` - Receiver where requested RequestTypes will come across
-    /// * `handle` - Handle to spawn new futures
-    pub fn new<T: DuplexTransport + 'static>(
-        homechain: &Rc<Network<T>>,
-        sidechain: &Rc<Network<T>>,
-        rx: mpsc::UnboundedReceiver<RequestType>,
-        handle: &reactor::Handle,
-    ) -> Self {
-        let handle = handle.clone();
-        let homechain = homechain.clone();
-        let sidechain = sidechain.clone();
-        let requests_future = rx.for_each(move |request| {
-            let homechain = homechain.clone();
-            let sidechain = sidechain.clone();
-            let handle = handle.clone();
-            match request {
-                RequestType::Hash(chain, tx_hash) => {
-                    let (source, target) = match chain {
-                        NetworkType::Home => (homechain, sidechain),
-                        NetworkType::Side => (sidechain, homechain),
-                    };
-                    future::Either::A(
-                        FindTransferInTransaction::new(&source, &tx_hash)
-                            .and_then(move |transfers| {
-                                let handle = handle.clone();
-                                let target = target.clone();
-                                let futures: Vec<ValidateAndApproveTransfer<T>> = transfers
-                                    .iter()
-                                    .map(move |transfer| {
-                                        let handle = handle.clone();
-                                        let target = target.clone();
-                                        ValidateAndApproveTransfer::new(&target, &handle, &transfer)
-                                    })
-                                    .collect();
-                                future::join_all(futures)
-                            })
-                            .and_then(|_| Ok(()))
-                            .or_else(move |_| {
-                                // No log here, errors are caught in Futures
-                                Ok(())
-                            }),
-                    )
+    let (balance_tx, balance_rx) = mpsc::unbounded();
+    let request_future: Box<Future<Item = HttpResponse, Error = EndpointError>> = Box::new(
+        balance_rx
+            .take(1)
+            .collect()
+            .and_then(move |messages: Vec<Result<BalanceResponse, ()>>| {
+                if !messages.is_empty() {
+                    Ok(messages[0].clone())
+                } else {
+                    Err(())
                 }
-                RequestType::Status(tx) => {
-                    let home_eth_future = homechain
-                        .web3
-                        .eth()
-                        .balance(homechain.account, None)
-                        .and_then(move |balance| Ok(Some(balance)))
-                        .or_else(|_| Ok(None));
+            })
+            .and_then(move |msg| match msg {
+                Ok(response) => {
+                    let body = serde_json::to_string(&response).map_err(move |e| {
+                        error!("error parsing response: {:?}", e);
+                    })?;
 
-                    let home_balance_query = BalanceQuery::new(homechain.relay.address());
-                    let home_nct_future = homechain
-                        .token
-                        .query::<BalanceOf, Address, BlockNumber, BalanceQuery>(
-                            "balanceOf",
-                            home_balance_query,
-                            homechain.account,
-                            Options::default(),
-                            BlockNumber::Latest,
-                        )
-                        .and_then(move |balance| Ok(Some(balance.0)))
-                        .or_else(move |_| Ok(None));
-
-                    let home_last_block_future = homechain
-                        .web3
-                        .eth()
-                        .block_number()
-                        .and_then(move |block| Ok(Some(block)))
-                        .or_else(|_| Ok(None));
-
-                    let side_eth_future = sidechain
-                        .web3
-                        .eth()
-                        .balance(sidechain.account, None)
-                        .and_then(move |balance| Ok(Some(balance)))
-                        .or_else(|_| Ok(None));
-                    let side_balance_query = BalanceQuery::new(sidechain.relay.address());
-                    let side_nct_future = sidechain
-                        .token
-                        .query::<BalanceOf, Address, BlockNumber, BalanceQuery>(
-                            "balanceOf",
-                            side_balance_query,
-                            sidechain.account,
-                            Options::default(),
-                            BlockNumber::Latest,
-                        )
-                        .and_then(move |balance| Ok(Some(balance.0)))
-                        .or_else(move |_| Ok(None));
-
-                    let side_last_block_future = sidechain
-                        .web3
-                        .eth()
-                        .block_number()
-                        .and_then(move |block| Ok(Some(block)))
-                        .or_else(|_| Ok(None));
-
-                    let futures: Vec<Box<Future<Item = Option<U256>, Error = ()>>> = vec![
-                        Box::new(home_eth_future),
-                        Box::new(home_last_block_future),
-                        Box::new(home_nct_future),
-                        Box::new(side_eth_future),
-                        Box::new(side_last_block_future),
-                        Box::new(side_nct_future),
-                    ];
-
-                    let tx = tx.clone();
-                    let error_tx = tx.clone();
-
-                    future::Either::B(
-                        future::join_all(futures)
-                            .and_then(move |results| {
-                                debug!("results from status futures: {:?}", results);
-                                let home = NetworkStatus::new(results[0], results[1], results[2]);
-                                let side = NetworkStatus::new(results[3], results[4], results[5]);
-                                Ok(StatusResponse::new(home, side))
-                            })
-                            .and_then(move |response| {
-                                debug!("Status response: {:?}", response);
-                                let tx: mpsc::UnboundedSender<Result<StatusResponse, ()>> = tx.clone();
-                                let send_result = tx.unbounded_send(Ok(response));
-                                if send_result.is_err() {
-                                    error!("error sending status response");
-                                }
-                                Ok(())
-                            })
-                            .or_else(move |e| {
-                                let tx = error_tx.clone();
-                                error!("error getting status: {:?}", e);
-                                let send_result = tx.unbounded_send(Err(()));
-                                if send_result.is_err() {
-                                    error!("error sending status response");
-                                }
-                                Ok(())
-                            }),
-                    )
+                    Ok(HttpResponse::Ok().content_type("application/json").body(body))
                 }
-            }
-        });
+                Err(_) => Err(()),
+            })
+            .map_err(|_| {
+                error!("error receiving message");
+                EndpointError::UnableToGetBalances
+            }),
+    );
 
-        HandleRequests {
-            future: Box::new(requests_future),
-        }
+    let request = RequestType::Balance(chain, balance_tx);
+    let send_result = tx.unbounded_send(request);
+    if send_result.is_err() {
+        error!("error sending balance request: {:?}", send_result.err());
+        return Box::new(future::err(EndpointError::UnableToGetBalances));
     }
-}
 
-impl Future for HandleRequests {
-    type Item = ();
-    type Error = ();
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.future.poll()
-    }
-}
-
-pub enum FindTransferState {
-    ExtractTransfers(Box<Future<Item = Vec<Transfer>, Error = ()>>),
-    FetchReceipt(Box<Future<Item = Option<TransactionReceipt>, Error = ()>>),
-}
-
-/// Future to find a vec of transfers at a specific transaction
-pub struct FindTransferInTransaction<T: DuplexTransport + 'static> {
-    hash: H256,
-    source: Rc<Network<T>>,
-    state: FindTransferState,
-}
-
-impl<T: DuplexTransport + 'static> FindTransferInTransaction<T> {
-    /// Returns a newly created FindTransferInTransaction Future
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - Network where the transaction took place
-    /// * `hash` - Transaction hash to check
-    fn new(source: &Rc<Network<T>>, hash: &H256) -> Self {
-        let web3 = source.web3.clone();
-        let network_type = source.network_type;
-        let future = web3.clone().eth().transaction_receipt(*hash).map_err(move |e| {
-            error!("error getting transaction receipt on {:?}: {:?}", network_type, e);
-        });
-        let state = FindTransferState::FetchReceipt(Box::new(future));
-        FindTransferInTransaction {
-            hash: *hash,
-            source: source.clone(),
-            state,
-        }
-    }
-}
-
-impl<T: DuplexTransport + 'static> Future for FindTransferInTransaction<T> {
-    type Item = Vec<Transfer>;
-    type Error = ();
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            let source = self.source.clone();
-            let network_type = source.network_type;
-            let hash = self.hash;
-            let next = match self.state {
-                FindTransferState::ExtractTransfers(ref mut future) => {
-                    let transfers = try_ready!(future.poll());
-                    if transfers.is_empty() {
-                        warn!("no relay transactions found on {:?} at {:?}", network_type, hash);
-                        return Err(());
-                    } else {
-                        return Ok(Async::Ready(transfers));
-                    }
-                }
-                FindTransferState::FetchReceipt(ref mut future) => {
-                    let receipt = try_ready!(future.poll());
-                    match receipt {
-                        Some(r) => {
-                            if r.block_hash.is_none() {
-                                error!("receipt did not have block hash on {:?}", network_type);
-                                return Err(());
-                            }
-                            let block_hash = r.block_hash.unwrap();
-                            r.block_number.map_or_else(
-                                || {
-                                    error!("receipt did not have block number on {:?}", network_type);
-                                    Err(())
-                                },
-                                |receipt_block| {
-                                    let future = source
-                                        .web3
-                                        .clone()
-                                        .eth()
-                                        .block_number()
-                                        .and_then(move |block| {
-                                            let mut transfers = Vec::new();
-                                            if let Some(confirmed) =
-                                                block.checked_rem(receipt_block).map(|u| u.as_u64())
-                                            {
-                                                if confirmed > source.confirmations {
-                                                    let logs = r.logs;
-                                                    for log in logs {
-                                                        info!(
-                                                            "found log at {:?} on {:?}: {:?}",
-                                                            hash, network_type, log
-                                                        );
-                                                        if log.topics[0] == TRANSFER_EVENT_SIGNATURE.into()
-                                                            && log.topics[2] == source.relay.address().into()
-                                                        {
-                                                            let destination: Address = log.topics[1].into();
-                                                            let amount: U256 = log.data.0[..32].into();
-                                                            if destination == Address::zero() {
-                                                                info!("found mint on {:?}. Skipping", network_type);
-                                                                continue;
-                                                            }
-                                                            let transfer = Transfer {
-                                                                destination,
-                                                                amount,
-                                                                tx_hash: hash,
-                                                                block_hash,
-                                                                block_number: receipt_block,
-                                                                removed: false,
-                                                            };
-                                                            transfers.push(transfer);
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            Ok(transfers)
-                                        })
-                                        .map_err(move |e| {
-                                            error!("error getting current block on {:?}: {:?}", network_type, e);
-                                        });
-                                    Ok(FindTransferState::ExtractTransfers(Box::new(future)))
-                                },
-                            )
-                        }
-                        None => {
-                            error!("unable to find {:?} on {:?}", hash, source.network_type);
-                            return Err(());
-                        }
-                    }?
-                }
-            };
-            self.state = next;
-        }
-    }
-}
-
-pub struct BalanceQuery {
-    address: Address,
-}
-
-impl BalanceQuery {
-    fn new(address: Address) -> Self {
-        BalanceQuery { address }
-    }
-}
-
-impl Tokenize for BalanceQuery {
-    fn into_tokens(self) -> Vec<Token> {
-        vec![Token::Address(self.address)]
-    }
-}
-
-/// Withdrawal event added to contract after a transfer
-#[derive(Debug, Clone)]
-pub struct BalanceOf(U256);
-
-impl Detokenize for BalanceOf {
-    /// Creates a new instance from parsed ABI tokens.
-    fn from_tokens(tokens: Vec<Token>) -> Result<Self, contract::Error>
-    where
-        Self: Sized,
-    {
-        let balance = tokens[0].clone().to_uint().ok_or_else(|| {
-            contract::Error::from_kind(contract::ErrorKind::Msg(
-                "cannot parse balance from contract response".to_string(),
-            ))
-        })?;
-        debug!("balance of: {:?}", balance);
-        Ok(BalanceOf(balance))
-    }
+    Box::new(request_future)
 }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -22,7 +22,7 @@ pub struct BalanceQuery {
 }
 
 impl BalanceQuery {
-    fn new(address: Address) -> Self {
+    pub fn new(address: Address) -> Self {
         BalanceQuery { address }
     }
 }
@@ -103,13 +103,14 @@ impl<T: DuplexTransport + 'static> Future for HandleRequests<T> {
                     let future = FindTransferInTransaction::new(&source, &tx_hash)
                         .and_then(move |transfers| {
                             let handle = handle.clone();
+                            let source = source.clone();
                             let target = target.clone();
                             let futures: Vec<ValidateAndApproveTransfer<T>> = transfers
                                 .iter()
                                 .map(move |transfer| {
                                     let handle = handle.clone();
                                     let target = target.clone();
-                                    ValidateAndApproveTransfer::new(&target, &handle, &transfer)
+                                    ValidateAndApproveTransfer::new(&source, &target, &handle, &transfer)
                                 })
                                 .collect();
                             future::join_all(futures)

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -1,11 +1,6 @@
-use eth::contracts::TRANSFER_EVENT_SIGNATURE;
 use ethabi::Token;
 use relay::{Network, NetworkType};
 use server::endpoint::{NetworkStatus, RequestType, StatusResponse};
-use std::cmp;
-use std::collections::HashMap;
-use std::rc::Rc;
-use std::time::Instant;
 use tokio_core::reactor;
 use transfers::past::{FindTransferInTransaction, ValidateAndApproveTransfer};
 use web3::contract::tokens::{Detokenize, Tokenize};
@@ -14,7 +9,7 @@ use web3::futures::future;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
 use web3::futures::try_ready;
-use web3::types::{Address, BlockNumber, FilterBuilder, Log, U256};
+use web3::types::{Address, BlockNumber, U256};
 use web3::{contract, DuplexTransport};
 
 pub struct BalanceQuery {

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -89,13 +89,10 @@ impl<T: DuplexTransport + 'static> Future for HandleRequests<T> {
     type Error = ();
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            match &mut self.in_progress {
-                Some(future) => {
-                    try_ready!(future.poll());
-                    self.in_progress = None;
-                }
-                _ => {}
-            };
+            if let Some(future) = &mut self.in_progress {
+                try_ready!(future.poll());
+                self.in_progress = None;
+            }
 
             let homechain = self.homechain.clone();
             let sidechain = self.sidechain.clone();

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -1,0 +1,338 @@
+use eth::contracts::TRANSFER_EVENT_SIGNATURE;
+use ethabi::Token;
+use relay::{Network, NetworkType};
+use server::endpoint::{BalanceResponse, NetworkStatus, RequestType, StatusResponse};
+use std::collections::HashMap;
+use std::rc::Rc;
+use tokio_core::reactor;
+use transfers::past::{FindTransferInTransaction, ValidateAndApproveTransfer};
+use web3::contract::tokens::{Detokenize, Tokenize};
+use web3::contract::Options;
+use web3::futures::future;
+use web3::futures::prelude::*;
+use web3::futures::sync::mpsc;
+use web3::futures::try_ready;
+use web3::types::{Address, BlockNumber, FilterBuilder, Log, U256};
+use web3::{contract, DuplexTransport};
+
+pub struct BalanceQuery {
+    address: Address,
+}
+
+impl BalanceQuery {
+    fn new(address: Address) -> Self {
+        BalanceQuery { address }
+    }
+}
+
+impl Tokenize for BalanceQuery {
+    fn into_tokens(self) -> Vec<Token> {
+        vec![Token::Address(self.address)]
+    }
+}
+
+/// Withdrawal event added to contract after a transfer
+#[derive(Debug, Clone)]
+pub struct BalanceOf(U256);
+
+impl Detokenize for BalanceOf {
+    /// Creates a new instance from parsed ABI tokens.
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self, contract::Error>
+    where
+        Self: Sized,
+    {
+        let balance = tokens[0].clone().to_uint().ok_or_else(|| {
+            contract::Error::from_kind(contract::ErrorKind::Msg(
+                "cannot parse balance from contract response".to_string(),
+            ))
+        })?;
+        debug!("balance of: {:?}", balance);
+        Ok(BalanceOf(balance))
+    }
+}
+
+pub struct HandleRequests<T: DuplexTransport + 'static> {
+    listen: mpsc::UnboundedReceiver<RequestType>,
+    in_progress: Option<Box<Future<Item = (), Error = ()>>>,
+    homechain: Rc<Network<T>>,
+    sidechain: Rc<Network<T>>,
+    handle: reactor::Handle,
+}
+
+impl<T: DuplexTransport + 'static> HandleRequests<T> {
+    /// Returns a newly created HandleMissedTransfers Future
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - Network where the missed transfers are captured
+    /// * `target` - Network where the transfer will be approved for a withdrawal
+    /// * `rx` - Receiver where requested RequestTypes will come across
+    /// * `handle` - Handle to spawn new futures
+    pub fn new(
+        homechain: &Rc<Network<T>>,
+        sidechain: &Rc<Network<T>>,
+        rx: mpsc::UnboundedReceiver<RequestType>,
+        handle: &reactor::Handle,
+    ) -> Self {
+        HandleRequests {
+            listen: rx,
+            in_progress: None,
+            homechain: homechain.clone(),
+            sidechain: sidechain.clone(),
+            handle: handle.clone(),
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for HandleRequests<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            match &mut self.in_progress {
+                Some(future) => {
+                    try_ready!(future.poll());
+                    self.in_progress = None;
+                }
+                _ => {}
+            };
+
+            let homechain = self.homechain.clone();
+            let sidechain = self.sidechain.clone();
+            let handle = self.handle.clone();
+            let request = try_ready!(self.listen.poll());
+            let next: Option<Box<Future<Item = (), Error = ()>>> = match request {
+                Some(RequestType::Hash(chain, tx_hash)) => {
+                    let (source, target) = match chain {
+                        NetworkType::Home => (homechain, sidechain),
+                        NetworkType::Side => (sidechain, homechain),
+                    };
+                    let future = FindTransferInTransaction::new(&source, &tx_hash)
+                        .and_then(move |transfers| {
+                            let target = target.clone();
+                            let futures: Vec<ValidateAndApproveTransfer<T>> = transfers
+                                .iter()
+                                .map(move |transfer| {
+                                    let handle = handle.clone();
+                                    let target = target.clone();
+                                    ValidateAndApproveTransfer::new(&target, &handle, &transfer)
+                                })
+                                .collect();
+                            future::join_all(futures)
+                        })
+                        .and_then(|_| Ok(()))
+                        .or_else(move |_| {
+                            // No log here, errors are caught in Futures
+                            Ok(())
+                        });
+                    Some(Box::new(future))
+                }
+                Some(RequestType::Status(ref tx)) => Some(Box::new(StatusCheck::new(&homechain, &sidechain, tx))),
+                Some(RequestType::Balance(chain, ref tx)) => {
+                    let source = match chain {
+                        NetworkType::Home => homechain,
+                        NetworkType::Side => sidechain,
+                    };
+                    Some(Box::new(BalanceCheck::new(&source, tx)))
+                }
+                None => None,
+            };
+            self.in_progress = next;
+        }
+    }
+}
+
+pub enum BalanceCheckState {
+    BuildFilter(Box<Future<Item = U256, Error = ()>>),
+    GetLogs(Box<Future<Item = Vec<Log>, Error = ()>>),
+}
+
+pub struct BalanceCheck<T: DuplexTransport + 'static> {
+    source: Rc<Network<T>>,
+    state: BalanceCheckState,
+    tx: mpsc::UnboundedSender<Result<BalanceResponse, ()>>,
+}
+
+impl<T: DuplexTransport + 'static> BalanceCheck<T> {
+    fn new(source: &Rc<Network<T>>, tx: &mpsc::UnboundedSender<Result<BalanceResponse, ()>>) -> Self {
+        let future = source.web3.eth().block_number().map_err(move |e| {
+            error!("error getting block number {:?}", e);
+        });
+
+        BalanceCheck {
+            source: source.clone(),
+            tx: tx.clone(),
+            state: BalanceCheckState::BuildFilter(Box::new(future)),
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for BalanceCheck<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let source = self.source.clone();
+            let tx = self.tx.clone();
+            let next = match &mut self.state {
+                BalanceCheckState::BuildFilter(future) => {
+                    let block = try_ready!(future.poll());
+                    let token_address = source.token.address();
+                    let filter = FilterBuilder::default()
+                        .address(vec![token_address])
+                        .from_block(BlockNumber::from(0))
+                        .to_block(BlockNumber::Number(block.as_u64()))
+                        .topics(Some(vec![TRANSFER_EVENT_SIGNATURE.into()]), None, None, None)
+                        .build();
+                    //self.state = ;
+                    let future = source.web3.eth().logs(filter).map_err(move |e| {
+                        error!("error getting block number {:?}", e);
+                    });
+                    BalanceCheckState::GetLogs(Box::new(future))
+                }
+                BalanceCheckState::GetLogs(future) => {
+                    let logs = try_ready!(future.poll());
+                    let mut results: HashMap<Address, U256> = HashMap::new();
+                    logs.iter().for_each(|log| {
+                        if Some(true) == log.removed {
+                            return;
+                        }
+
+                        log.transaction_hash.map_or_else(
+                            || {
+                                warn!("log missing transaction hash on {:?}", source.network_type);
+                            },
+                            |tx_hash| {
+                                let sender_address: Address = log.topics[1].into();
+                                let receiver_address: Address = log.topics[2].into();
+                                let amount: U256 = log.data.0[..32].into();
+                                // Don't care if source doesn't exist, because it is likely a mint in that case
+                                let source_balance = results
+                                    .entry(sender_address)
+                                    .and_modify(|v| {
+                                        if !v.is_zero() {
+                                            *v -= amount;
+                                        }
+                                    })
+                                    .or_insert(0.into());
+                                let dest_balance = results.entry(receiver_address).or_insert(0.into());
+                                *dest_balance += amount;
+                            },
+                        );
+                    });
+                    let send_result = tx.unbounded_send(Ok(BalanceResponse::new(&results)));
+                    if send_result.is_err() {
+                        error!("error sending balance response");
+                    }
+                    return Ok(Async::Ready(()));
+                }
+            };
+            self.state = next;
+        }
+    }
+}
+
+pub struct StatusCheck {
+    future: Box<Future<Item = Vec<Option<U256>>, Error = ()>>,
+    tx: mpsc::UnboundedSender<Result<StatusResponse, ()>>,
+}
+
+impl StatusCheck {
+    fn new<T: DuplexTransport + 'static>(
+        homechain: &Rc<Network<T>>,
+        sidechain: &Rc<Network<T>>,
+        tx: &mpsc::UnboundedSender<Result<StatusResponse, ()>>,
+    ) -> Self {
+        let home_eth_future = homechain
+            .web3
+            .eth()
+            .balance(homechain.account, None)
+            .and_then(move |balance| Ok(Some(balance)))
+            .or_else(|_| Ok(None));
+
+        let home_balance_query = BalanceQuery::new(homechain.relay.address());
+        let home_nct_future = homechain
+            .token
+            .query::<BalanceOf, Address, BlockNumber, BalanceQuery>(
+                "balanceOf",
+                home_balance_query,
+                homechain.account,
+                Options::default(),
+                BlockNumber::Latest,
+            )
+            .and_then(move |balance| Ok(Some(balance.0)))
+            .or_else(move |_| Ok(None));
+
+        let home_last_block_future = homechain
+            .web3
+            .eth()
+            .block_number()
+            .and_then(move |block| Ok(Some(block)))
+            .or_else(|_| Ok(None));
+
+        let side_eth_future = sidechain
+            .web3
+            .eth()
+            .balance(sidechain.account, None)
+            .and_then(move |balance| Ok(Some(balance)))
+            .or_else(|_| Ok(None));
+        let side_balance_query = BalanceQuery::new(sidechain.relay.address());
+        let side_nct_future = sidechain
+            .token
+            .query::<BalanceOf, Address, BlockNumber, BalanceQuery>(
+                "balanceOf",
+                side_balance_query,
+                sidechain.account,
+                Options::default(),
+                BlockNumber::Latest,
+            )
+            .and_then(move |balance| Ok(Some(balance.0)))
+            .or_else(move |_| Ok(None));
+
+        let side_last_block_future = sidechain
+            .web3
+            .eth()
+            .block_number()
+            .and_then(move |block| Ok(Some(block)))
+            .or_else(|_| Ok(None));
+
+        let futures: Vec<Box<Future<Item = Option<U256>, Error = ()>>> = vec![
+            Box::new(home_eth_future),
+            Box::new(home_last_block_future),
+            Box::new(home_nct_future),
+            Box::new(side_eth_future),
+            Box::new(side_last_block_future),
+            Box::new(side_nct_future),
+        ];
+        let future = Box::new(future::join_all(futures));
+        StatusCheck { future, tx: tx.clone() }
+    }
+}
+
+impl Future for StatusCheck {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let results = self.future.poll();
+        match results {
+            Ok(Async::Ready(results)) => {
+                let home = NetworkStatus::new(results[0], results[1], results[2]);
+                let side = NetworkStatus::new(results[3], results[4], results[5]);
+                let send_result = self.tx.unbounded_send(Ok(StatusResponse::new(home, side)));
+                if send_result.is_err() {
+                    error!("error sending status response");
+                }
+            }
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Err(e) => {
+                error!("error getting status: {:?}", e);
+                let send_result = self.tx.unbounded_send(Err(()));
+                if send_result.is_err() {
+                    error!("error sending status response");
+                }
+            }
+            _ => {}
+        };
+        Ok(Async::Ready(()))
+    }
+}

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -35,7 +35,7 @@ impl Tokenize for BalanceQuery {
 
 /// Withdrawal event added to contract after a transfer
 #[derive(Debug, Clone)]
-pub struct BalanceOf(U256);
+pub struct BalanceOf(pub U256);
 
 impl Detokenize for BalanceOf {
     /// Creates a new instance from parsed ABI tokens.

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -217,6 +217,7 @@ impl<T: DuplexTransport + 'static> Future for BalanceCheck<T> {
                         *dest_balance += amount;
                     });
 
+                    info!("Window end is {} of {} blocks", window_end, end);
                     // Setup next window
                     if window_end < end {
                         let next_window_end = cmp::min(end, window_end + 1000);

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -2,9 +2,9 @@ use eth::contracts::TRANSFER_EVENT_SIGNATURE;
 use ethabi::Token;
 use relay::{Network, NetworkType};
 use server::endpoint::{BalanceResponse, NetworkStatus, RequestType, StatusResponse};
+use std::cmp;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::cmp;
 use tokio_core::reactor;
 use transfers::past::{FindTransferInTransaction, ValidateAndApproveTransfer};
 use web3::contract::tokens::{Detokenize, Tokenize};
@@ -129,7 +129,7 @@ impl<T: DuplexTransport + 'static> Future for HandleRequests<T> {
                     info!("Checking all token balances");
                     handle.spawn(BalanceCheck::new(&source, tx))
                 }
-                None => {},
+                None => {}
             };
         }
     }
@@ -161,7 +161,7 @@ impl<T: DuplexTransport + 'static> BalanceCheck<T> {
         }
     }
 
-    fn build_next_window(&self, start: u64, end: u64) -> Box<Future<Item=Vec<Log>, Error = ()>> {
+    fn build_next_window(&self, start: u64, end: u64) -> Box<Future<Item = Vec<Log>, Error = ()>> {
         let token_address: Address = self.source.token.address();
         let filter = FilterBuilder::default()
             .address(vec![token_address])

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,10 @@
 pub mod endpoint;
+pub mod handler;
 
 use super::errors;
 use super::eth;
 use super::relay;
 use super::transfers;
+
+pub use self::endpoint::RequestType;
+pub use self::handler::HandleRequests;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,7 +4,6 @@ pub mod handler;
 use super::errors;
 use super::eth;
 use super::relay;
-use super::transfers;
 
 pub use self::endpoint::RequestType;
 pub use self::handler::HandleRequests;

--- a/src/transfers/flush.rs
+++ b/src/transfers/flush.rs
@@ -17,6 +17,7 @@ use web3::types::{Address, BlockNumber, Bytes, FilterBuilder, Log, TransactionRe
 use web3::{contract, DuplexTransport};
 use actix_web::web::block;
 
+/// Simple struct with an Address and Balance that represents an ethereum wallet
 #[derive(Clone, Copy, Ord, Eq, PartialEq, PartialOrd)]
 pub struct Wallet {
     address: Address,
@@ -24,6 +25,11 @@ pub struct Wallet {
 }
 
 impl Wallet {
+    /// Create a new wallet
+    /// # Arguments
+    ///
+    /// * `address` - Address for the wallet
+    /// * `balance` - Current balance of tokens at the wallet
     fn new(address: &Address, balance: &U256) -> Self {
         Wallet {
             address: *address,
@@ -31,6 +37,13 @@ impl Wallet {
         }
     }
 
+    /// Create a SendTransaction Future that performs a withdrawal on the target chain
+    /// # Arguments
+    ///
+    /// * `target` - Network to withdrawl from
+    /// * `transaction_hash`- Transaction hash of the flush
+    /// * `block_hash` - Block hash of the flush
+    /// * `block_number` - Modified block number of the flush. Will not match the actual block number to avoid collisions in the contract
     fn withdraw<T: DuplexTransport + 'static>(&self, target: &Network<T>,  transaction_hash: &H256, block_hash: &H256, block_number: &U256) -> SendTransaction<T, ApproveParams> {
         let approve_params = ApproveParams {
             destination: self.address,

--- a/src/transfers/flush.rs
+++ b/src/transfers/flush.rs
@@ -273,7 +273,7 @@ impl<T: DuplexTransport + 'static> Future for ProcessFlush<T> {
                                 .filter_map(|(address, balance)| {
                                     let transfer = Transfer::from_receipt(*address, *balance, false, &receipt);
                                     match transfer {
-                                        Ok(t) => Some(t.approve_withdrawal(&source, &target)),
+                                        Ok(t) => Some(t.approve_withdrawal(&source, &target, false)),
                                         Err(e) => {
                                             error!(
                                                 "error creating transfer to {} for {} nct from receipt: {:?}",
@@ -453,9 +453,9 @@ impl<T: DuplexTransport + 'static> Future for WithdrawLeftovers<T> {
                         Some(b) => {
                             info!("withdrawing {} to fee wallet {}", b, address.0);
                             match Transfer::from_receipt(address.0, b, false, &receipt) {
-                                Ok(transfer) => {
-                                    WithdrawLeftoversState::Withdraw(transfer.approve_withdrawal(&source, &target))
-                                }
+                                Ok(transfer) => WithdrawLeftoversState::Withdraw(
+                                    transfer.approve_withdrawal(&source, &target, false),
+                                ),
                                 Err(e) => {
                                     error!("Error creating transaction from flush receipt: {:?}", e);
                                     return Err(());

--- a/src/transfers/flush.rs
+++ b/src/transfers/flush.rs
@@ -331,7 +331,7 @@ impl<T: DuplexTransport + 'static> Future for ProcessFlush<T> {
                                 .iter()
                                 .enumerate()
                                 .filter_map(|(i, wallet)| {
-                                    Some(wallet.withdraw(&target, &receipt.transaction_hash, &block_hash, &(block_number + i)))
+                                    Some(wallet.withdraw(&target, &receipt.transaction_hash, &block_hash, &(block_number + i))
                                 })
                                 .collect();
 
@@ -350,7 +350,7 @@ impl<T: DuplexTransport + 'static> Future for ProcessFlush<T> {
 
                     match flush_receipt {
                         Some(receipt) => {
-                            ProcessFlushState::WithdrawLeftovers(WithdrawLeftovers::new(&source, &target, &receipt, withdrawals.len()))
+                            ProcessFlushState::WithdrawLeftovers(WithdrawLeftovers::new(&source, &target, &receipt, withdrawals.len() + 1))
                         }
                         None => {
                             error!("No flush receipt available");

--- a/src/transfers/flush.rs
+++ b/src/transfers/flush.rs
@@ -1,0 +1,413 @@
+//use actix_web::Either;
+//use eth::contracts::{FLUSH_EVENT_SIGNATURE, TRANSFER_EVENT_SIGNATURE};
+//use extensions::removed::{CancelRemoved, ExitOnLogRemoved};
+//use extensions::timeout::SubscriptionState;
+//use relay::{Network, NetworkType, TransferApprovalState};
+//use server::endpoint::BalanceResponse;
+//use std::collections::HashMap;
+//use std::rc::Rc;
+//use std::sync::{PoisonError, RwLockWriteGuard};
+//use std::time::Instant;
+//use std::{cmp, time};
+//use tokio::sync::mpsc;
+//use tokio_core::reactor;
+//use transfers::transfer::Transfer;
+//use web3::confirm::{wait_for_transaction_confirmation, SendTransactionWithConfirmation};
+//use web3::contract::ErrorKind;
+//use web3::futures::prelude::*;
+//use web3::types::{Address, BlockNumber, Log, TransactionReceipt, H256, U256};
+//use web3::DuplexTransport;
+//use lru::LruCache;
+//
+//impl<T> CancelRemoved<T, TransactionReceipt, web3::Error> for SendTransactionWithConfirmation<T>
+//where
+//    T: DuplexTransport + 'static,
+//{
+//    fn cancel_removed(
+//        self,
+//        target: &Network<T>,
+//        tx_hash: H256,
+//    ) -> ExitOnLogRemoved<T, TransactionReceipt, web3::Error> {
+//        ExitOnLogRemoved::new(target.clone(), tx_hash, Box::new(self))
+//    }
+//}
+//
+///// Stream of transfer events that have been on the main chain for N blocks.
+///// N is confirmations per settings.
+//pub struct WatchFlush<T: DuplexTransport + 'static> {
+//    transaction_hash_processor: TransactionHashProcessor<T>,
+//    state: SubscriptionState<T, Log>,
+//    handle: reactor::Handle,
+//}
+//
+//impl<T: DuplexTransport + 'static> WatchFlush<T> {
+//    /// Returns a newly created WatchTransfers Stream
+//    ///
+//    /// # Arguments
+//    ///
+//    /// * `source` - Network where the transfers are performed
+//    /// * `handle` - Handle to spawn naew futures
+//    pub fn new(
+//        source: &Network<T>,
+//        target: &Network<T>,
+//        handle: &reactor::Handle,
+//    ) -> Self {
+//        let filter = FilterBuilder::default()
+//            .address(vec![source.relay.address()])
+//            .topics(Some(vec![FLUSH_EVENT_SIGNATURE.into()]), None, None, None)
+//            .build();
+//
+//        let future = Box::new(source.web3.clone().eth_subscribe().subscribe_logs(filter));
+//
+//        let transaction_processor = TransactionHashProcessor::new(
+//            source.network_type,
+//            source.confirmations,
+//            &target,
+//            &source.web3.transport().clone(),
+//            tx,
+//        );
+//
+//        WatchFlush {
+//            transaction_hash_processor: transaction_processor,
+//            state: SubscriptionState::Subscribing(future),
+//            handle: handle.clone(),
+//        }
+//    }
+//
+//    fn process_log(
+//        log: &Log,
+//        transaction_hash_processor: &TransactionHashProcessor<T>,
+//    ) -> Option<Box<Future<Item = (), Error = ()>>> {
+//        let destination: Address = log.topics[1].into();
+//        let amount: U256 = log.data.0[..32].into();
+//        let removed = log.removed;
+//        let processor = transaction_hash_processor.clone();
+//        log.transaction_hash.map_or_else(
+//            || {
+//                warn!("log missing transaction hash on {:?}", processor.network_type);
+//                None
+//            },
+//            |tx_hash| {
+//                // Handle confirmed flush here
+//                let future = processor.process(destination, amount, removed, tx_hash)
+//                .and_then(move |receipt| {
+//                    let transfer_result =
+//                        Transfer::from_receipt(destination, amount, removed, &receipt.ok_or(())?);
+//                    match transfer_result {
+//                        Ok(transfer) => {
+//                            info!(
+//                                "transfer event on {:?} confirmed, approving {}",
+//                                network_type, &transfer
+//                            );
+//                            tx.unbounded_send(transfer).unwrap();
+//                            Ok(())
+//                        }
+//                        Err(msg) => {
+//                            error!(
+//                                "error producing transfer from receipt on {:?}: {}",
+//                                network_type, msg
+//                            );
+//                            Err(())
+//                        }
+//                    }
+//                })
+//                .map_err(move |e| {
+//                    error!(
+//                        "error getting removed transaction receipt on {:?}: {:?}",
+//                        network_type, e
+//                    );
+//                });
+//                Some(future)
+//            }
+//        )
+//    }
+//}
+//
+//impl<T: DuplexTransport + 'static> Future for WatchFlush<T> {
+//    type Item = ();
+//    type Error = web3::Error;
+//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+//        loop {
+//            let handle = self.handle.clone();
+//            let processor = self.transaction_hash_processor.clone();
+//            let next = match self.state {
+//                SubscriptionState::Subscribing(ref mut future) => {
+//                    let stream = try_ready!(future.poll());
+//                    Some(SubscriptionState::Subscribed(stream))
+//                }
+//                SubscriptionState::Subscribed(ref mut stream) => {
+//                    match stream.poll() {
+//                        Ok(Async::Ready(Some(log))) => {
+//                            let process_future = WatchFlush::<T>::process_log(&log, &processor);
+//                            if let Some(future) = process_future {
+//                                // TODO Handle confirmed flush here
+//                                // Create new state to get balances
+//
+//                            }
+//                        }
+//                        Ok(Async::Ready(None)) => {
+//                            self.transaction_hash_processor.tx.close().map_err(move |_| {
+//                                web3::Error::from_kind(ErrorKind::Msg("Unable to close sender".to_string()))
+//                            })?;
+//                            return Ok(Async::Ready(()));
+//                        }
+//                        Ok(Async::NotReady) => {
+//                            return Ok(Async::NotReady);
+//                        }
+//                        Err(e) => {
+//                            error!("error reading transfer logs on {:?}. {:?}", processor.network_type, e);
+//                            self.transaction_hash_processor.tx.close().map_err(move |_| {
+//                                web3::Error::from_kind(ErrorKind::Msg("Unable to close sender".to_string()))
+//                            })?;
+//                            return Err(e);
+//                        }
+//                    };
+//                    None
+//                }
+//            };
+//            if let Some(next_state) = next {
+//                self.state = next_state;
+//            }
+//        }
+//    }
+//}
+//
+//pub struct ProcessTransfer<T: DuplexTransport + 'static> {
+//    rx: mpsc::UnboundedReceiver<Transfer>,
+//    handle: reactor::Handle,
+//    target: Network<T>,
+//}
+//
+//impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
+//    pub fn new(rx: mpsc::UnboundedReceiver<Transfer>, target: &Network<T>, handle: &reactor::Handle) -> Self {
+//        ProcessTransfer {
+//            rx,
+//            target: target.clone(),
+//            handle: handle.clone(),
+//        }
+//    }
+//
+//    pub fn advance_transfer_approval(
+//        &self,
+//        transfer: Transfer,
+//        state: Option<TransferApprovalState>,
+//    ) -> Result<(), PoisonError<RwLockWriteGuard<'_, LruCache<H256, TransferApprovalState>>>> {
+//        match state {
+//            Some(TransferApprovalState::Sent) => {
+//                if transfer.removed {
+//                    self.target
+//                        .pending
+//                        .write()?
+//                        .put(transfer.tx_hash, TransferApprovalState::Removed);
+//                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target));
+//                }
+//            }
+//            Some(TransferApprovalState::Removed) => {
+//                // Remove logs can be added again
+//                if !transfer.removed {
+//                    self.target
+//                        .pending
+//                        .write()?
+//                        .put(transfer.tx_hash, TransferApprovalState::Sent);
+//                    self.handle.spawn(transfer.approve_withdrawal(&self.target));
+//                }
+//            }
+//            None => {
+//                if transfer.removed {
+//                    // Write removed state
+//                    self.target
+//                        .pending
+//                        .write()?
+//                        .put(transfer.tx_hash, TransferApprovalState::Removed);
+//                    // LRU Cache will drop values, so we need to recheck the chain
+//                    let target = self.target.clone();
+//                    let unapprove_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
+//                        if !not_approved {
+//                            Either::A(transfer.unapprove_withdrawal(&target))
+//                        } else {
+//                            Either::B(ok(()))
+//                        }
+//                    });
+//                    self.handle.spawn(unapprove_future);
+//                } else {
+//                    self.target
+//                        .pending
+//                        .write()?
+//                        .put(transfer.tx_hash, TransferApprovalState::Sent);
+//
+//                    // LRU Cache will drop values, so we need to recheck the chain
+//                    let target = self.target.clone();
+//                    let approve_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
+//                        if not_approved {
+//                            Either::A(transfer.approve_withdrawal(&target))
+//                        } else {
+//                            Either::B(ok(()))
+//                        }
+//                    });
+//                    self.handle.spawn(approve_future);
+//                }
+//            }
+//        };
+//        Ok(())
+//    }
+//}
+//
+//impl<T: DuplexTransport + 'static> Future for ProcessTransfer<T> {
+//    type Item = ();
+//    type Error = ();
+//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+//        loop {
+//            let transfer = try_ready!(self.rx.poll());
+//            match transfer {
+//                Some(t) => {
+//                    let value = {
+//                        let lock = self.target.pending.read().map_err(|e| {
+//                            error!("Failed to acquire read lock {:?}", e);
+//                        })?;
+//
+//                        lock.peek(&t.tx_hash).copied()
+//                    };
+//                    self.advance_transfer_approval(t, value).map_err(|e| {
+//                        error!("Failed to acquire write lock {:?}", e);
+//                    })?;
+//                }
+//                None => {
+//                    return Ok(Async::Ready(()));
+//                }
+//            };
+//        }
+//    }
+//}
+//
+//pub struct IsContract<T: DuplexTransport + 'static> {
+//    source: Network<T>,
+//    address: Address,
+//    future: Vec<U256>,
+//}
+//
+//impl<T: DuplexTransport + 'static> IsContract<T> {
+//    pub fn new(source: &Network<T>, wallet: &Address) {
+//        // Get contract data
+//    }
+//}
+//
+//impl<T: DuplexTransport + 'static> Future for IsContract<T> {
+//    type Item = bool;
+//    type Error = ();
+//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+//        let bytes = try_ready!(self.future.poll());
+//        Ok(Async::Ready(bytes == "0x"))
+//    }
+//}
+//
+//pub enum BalanceCheckState {
+//    GetEndingBlock(Box<Future<Item = U256, Error = ()>>),
+//    GetLogWindow(u64, u64, Box<Future<Item = Vec<Log>, Error = ()>>),
+//}
+//
+//pub struct BalanceCheck<T: DuplexTransport + 'static> {
+//    source: Network<T>,
+//    state: BalanceCheckState,
+//    tx: mpsc::UnboundedSender<Result<BalanceResponse, ()>>,
+//    balances: HashMap<Address, U256>,
+//    start: Instant,
+//}
+//
+//impl<T: DuplexTransport + 'static> BalanceCheck<T> {
+//    fn new(source: &Network<T>, tx: &mpsc::UnboundedSender<Result<BalanceResponse, ()>>) -> Self {
+//        let future = source.web3.eth().block_number().map_err(move |e| {
+//            error!("error getting block number {:?}", e);
+//        });
+//
+//        BalanceCheck {
+//            source: source.clone(),
+//            tx: tx.clone(),
+//            state: BalanceCheckState::GetEndingBlock(Box::new(future)),
+//            balances: HashMap::new(),
+//            start: Instant::now(),
+//        }
+//    }
+//
+//    fn build_next_window(&self, start: u64, end: u64) -> Box<Future<Item = Vec<Log>, Error = ()>> {
+//        let token_address: Address = self.source.token.address();
+//        let filter = FilterBuilder::default()
+//            .address(vec![token_address])
+//            .from_block(BlockNumber::from(start))
+//            .to_block(BlockNumber::Number(end))
+//            .topics(Some(vec![TRANSFER_EVENT_SIGNATURE.into()]), None, None, None)
+//            .build();
+//        //self.state = ;
+//        let future = self.source.web3.eth().logs(filter).map_err(move |e| {
+//            error!("error getting block number {:?}", e);
+//        });
+//        Box::new(future)
+//    }
+//}
+//
+//impl<T: DuplexTransport + 'static> Future for BalanceCheck<T> {
+//    type Item = ();
+//    type Error = ();
+//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+//        loop {
+//            let tx = self.tx.clone();
+//            let next = match self.state {
+//                BalanceCheckState::GetEndingBlock(ref mut future) => {
+//                    let block = try_ready!(future.poll());
+//                    let window_end = cmp::min(block.as_u64(), 1000);
+//                    let future = self.build_next_window(0, window_end);
+//                    BalanceCheckState::GetLogWindow(block.as_u64(), window_end, future)
+//                }
+//                BalanceCheckState::GetLogWindow(end, window_end, ref mut future) => {
+//                    let logs = try_ready!(future.poll());
+//                    info!(
+//                        "found {} logs with transfers between {} and {}",
+//                        logs.len(),
+//                        window_end,
+//                        end
+//                    );
+//                    // Process existing logs
+//                    logs.iter().for_each(|log| {
+//                        if Some(true) == log.removed {
+//                            return;
+//                        }
+//
+//                        let sender_address: Address = log.topics[1].into();
+//                        let receiver_address: Address = log.topics[2].into();
+//                        let amount: U256 = log.data.0[..32].into();
+//                        debug!("{} transferred {} to {}", sender_address, amount, receiver_address);
+//                        // Don't care if source doesn't exist, because it is likely a mint in that case
+//                        let zero = U256::zero();
+//                        self.balances
+//                            .entry(sender_address)
+//                            .and_modify(|v| {
+//                                if !v.is_zero() {
+//                                    *v -= amount;
+//                                }
+//                            })
+//                            .or_insert(zero);
+//                        let dest_balance = self.balances.entry(receiver_address).or_insert(zero);
+//                        *dest_balance += amount;
+//                    });
+//
+//                    debug!("Window end is {} of {} blocks", window_end, end);
+//                    // Setup next window
+//                    if window_end < end {
+//                        let next_window_end = cmp::min(end, window_end + 1000);
+//                        let future = self.build_next_window(window_end + 1, next_window_end);
+//                        BalanceCheckState::GetLogWindow(end, next_window_end, future)
+//                    } else {
+//                        let send_result = tx.unbounded_send(Ok(BalanceResponse::new(
+//                            &Instant::now().duration_since(self.start),
+//                            &self.balances.clone(),
+//                        )));
+//                        if send_result.is_err() {
+//                            error!("error sending balance response");
+//                        }
+//                        return Ok(Async::Ready(()));
+//                    }
+//                }
+//            };
+//            self.state = next;
+//        }
+//    }
+//}

--- a/src/transfers/flush.rs
+++ b/src/transfers/flush.rs
@@ -1,413 +1,499 @@
-//use actix_web::Either;
-//use eth::contracts::{FLUSH_EVENT_SIGNATURE, TRANSFER_EVENT_SIGNATURE};
-//use extensions::removed::{CancelRemoved, ExitOnLogRemoved};
-//use extensions::timeout::SubscriptionState;
-//use relay::{Network, NetworkType, TransferApprovalState};
-//use server::endpoint::BalanceResponse;
-//use std::collections::HashMap;
-//use std::rc::Rc;
-//use std::sync::{PoisonError, RwLockWriteGuard};
-//use std::time::Instant;
-//use std::{cmp, time};
-//use tokio::sync::mpsc;
-//use tokio_core::reactor;
-//use transfers::transfer::Transfer;
-//use web3::confirm::{wait_for_transaction_confirmation, SendTransactionWithConfirmation};
-//use web3::contract::ErrorKind;
-//use web3::futures::prelude::*;
-//use web3::types::{Address, BlockNumber, Log, TransactionReceipt, H256, U256};
-//use web3::DuplexTransport;
-//use lru::LruCache;
-//
-//impl<T> CancelRemoved<T, TransactionReceipt, web3::Error> for SendTransactionWithConfirmation<T>
-//where
-//    T: DuplexTransport + 'static,
-//{
-//    fn cancel_removed(
-//        self,
-//        target: &Network<T>,
-//        tx_hash: H256,
-//    ) -> ExitOnLogRemoved<T, TransactionReceipt, web3::Error> {
-//        ExitOnLogRemoved::new(target.clone(), tx_hash, Box::new(self))
-//    }
-//}
-//
-///// Stream of transfer events that have been on the main chain for N blocks.
-///// N is confirmations per settings.
-//pub struct WatchFlush<T: DuplexTransport + 'static> {
-//    transaction_hash_processor: TransactionHashProcessor<T>,
-//    state: SubscriptionState<T, Log>,
-//    handle: reactor::Handle,
-//}
-//
-//impl<T: DuplexTransport + 'static> WatchFlush<T> {
-//    /// Returns a newly created WatchTransfers Stream
-//    ///
-//    /// # Arguments
-//    ///
-//    /// * `source` - Network where the transfers are performed
-//    /// * `handle` - Handle to spawn naew futures
-//    pub fn new(
-//        source: &Network<T>,
-//        target: &Network<T>,
-//        handle: &reactor::Handle,
-//    ) -> Self {
-//        let filter = FilterBuilder::default()
-//            .address(vec![source.relay.address()])
-//            .topics(Some(vec![FLUSH_EVENT_SIGNATURE.into()]), None, None, None)
-//            .build();
-//
-//        let future = Box::new(source.web3.clone().eth_subscribe().subscribe_logs(filter));
-//
-//        let transaction_processor = TransactionHashProcessor::new(
-//            source.network_type,
-//            source.confirmations,
-//            &target,
-//            &source.web3.transport().clone(),
-//            tx,
-//        );
-//
-//        WatchFlush {
-//            transaction_hash_processor: transaction_processor,
-//            state: SubscriptionState::Subscribing(future),
-//            handle: handle.clone(),
-//        }
-//    }
-//
-//    fn process_log(
-//        log: &Log,
-//        transaction_hash_processor: &TransactionHashProcessor<T>,
-//    ) -> Option<Box<Future<Item = (), Error = ()>>> {
-//        let destination: Address = log.topics[1].into();
-//        let amount: U256 = log.data.0[..32].into();
-//        let removed = log.removed;
-//        let processor = transaction_hash_processor.clone();
-//        log.transaction_hash.map_or_else(
-//            || {
-//                warn!("log missing transaction hash on {:?}", processor.network_type);
-//                None
-//            },
-//            |tx_hash| {
-//                // Handle confirmed flush here
-//                let future = processor.process(destination, amount, removed, tx_hash)
-//                .and_then(move |receipt| {
-//                    let transfer_result =
-//                        Transfer::from_receipt(destination, amount, removed, &receipt.ok_or(())?);
-//                    match transfer_result {
-//                        Ok(transfer) => {
-//                            info!(
-//                                "transfer event on {:?} confirmed, approving {}",
-//                                network_type, &transfer
-//                            );
-//                            tx.unbounded_send(transfer).unwrap();
-//                            Ok(())
-//                        }
-//                        Err(msg) => {
-//                            error!(
-//                                "error producing transfer from receipt on {:?}: {}",
-//                                network_type, msg
-//                            );
-//                            Err(())
-//                        }
-//                    }
-//                })
-//                .map_err(move |e| {
-//                    error!(
-//                        "error getting removed transaction receipt on {:?}: {:?}",
-//                        network_type, e
-//                    );
-//                });
-//                Some(future)
-//            }
-//        )
-//    }
-//}
-//
-//impl<T: DuplexTransport + 'static> Future for WatchFlush<T> {
-//    type Item = ();
-//    type Error = web3::Error;
-//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//        loop {
-//            let handle = self.handle.clone();
-//            let processor = self.transaction_hash_processor.clone();
-//            let next = match self.state {
-//                SubscriptionState::Subscribing(ref mut future) => {
-//                    let stream = try_ready!(future.poll());
-//                    Some(SubscriptionState::Subscribed(stream))
-//                }
-//                SubscriptionState::Subscribed(ref mut stream) => {
-//                    match stream.poll() {
-//                        Ok(Async::Ready(Some(log))) => {
-//                            let process_future = WatchFlush::<T>::process_log(&log, &processor);
-//                            if let Some(future) = process_future {
-//                                // TODO Handle confirmed flush here
-//                                // Create new state to get balances
-//
-//                            }
-//                        }
-//                        Ok(Async::Ready(None)) => {
-//                            self.transaction_hash_processor.tx.close().map_err(move |_| {
-//                                web3::Error::from_kind(ErrorKind::Msg("Unable to close sender".to_string()))
-//                            })?;
-//                            return Ok(Async::Ready(()));
-//                        }
-//                        Ok(Async::NotReady) => {
-//                            return Ok(Async::NotReady);
-//                        }
-//                        Err(e) => {
-//                            error!("error reading transfer logs on {:?}. {:?}", processor.network_type, e);
-//                            self.transaction_hash_processor.tx.close().map_err(move |_| {
-//                                web3::Error::from_kind(ErrorKind::Msg("Unable to close sender".to_string()))
-//                            })?;
-//                            return Err(e);
-//                        }
-//                    };
-//                    None
-//                }
-//            };
-//            if let Some(next_state) = next {
-//                self.state = next_state;
-//            }
-//        }
-//    }
-//}
-//
-//pub struct ProcessTransfer<T: DuplexTransport + 'static> {
-//    rx: mpsc::UnboundedReceiver<Transfer>,
-//    handle: reactor::Handle,
-//    target: Network<T>,
-//}
-//
-//impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
-//    pub fn new(rx: mpsc::UnboundedReceiver<Transfer>, target: &Network<T>, handle: &reactor::Handle) -> Self {
-//        ProcessTransfer {
-//            rx,
-//            target: target.clone(),
-//            handle: handle.clone(),
-//        }
-//    }
-//
-//    pub fn advance_transfer_approval(
-//        &self,
-//        transfer: Transfer,
-//        state: Option<TransferApprovalState>,
-//    ) -> Result<(), PoisonError<RwLockWriteGuard<'_, LruCache<H256, TransferApprovalState>>>> {
-//        match state {
-//            Some(TransferApprovalState::Sent) => {
-//                if transfer.removed {
-//                    self.target
-//                        .pending
-//                        .write()?
-//                        .put(transfer.tx_hash, TransferApprovalState::Removed);
-//                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target));
-//                }
-//            }
-//            Some(TransferApprovalState::Removed) => {
-//                // Remove logs can be added again
-//                if !transfer.removed {
-//                    self.target
-//                        .pending
-//                        .write()?
-//                        .put(transfer.tx_hash, TransferApprovalState::Sent);
-//                    self.handle.spawn(transfer.approve_withdrawal(&self.target));
-//                }
-//            }
-//            None => {
-//                if transfer.removed {
-//                    // Write removed state
-//                    self.target
-//                        .pending
-//                        .write()?
-//                        .put(transfer.tx_hash, TransferApprovalState::Removed);
-//                    // LRU Cache will drop values, so we need to recheck the chain
-//                    let target = self.target.clone();
-//                    let unapprove_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
-//                        if !not_approved {
-//                            Either::A(transfer.unapprove_withdrawal(&target))
-//                        } else {
-//                            Either::B(ok(()))
-//                        }
-//                    });
-//                    self.handle.spawn(unapprove_future);
-//                } else {
-//                    self.target
-//                        .pending
-//                        .write()?
-//                        .put(transfer.tx_hash, TransferApprovalState::Sent);
-//
-//                    // LRU Cache will drop values, so we need to recheck the chain
-//                    let target = self.target.clone();
-//                    let approve_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
-//                        if not_approved {
-//                            Either::A(transfer.approve_withdrawal(&target))
-//                        } else {
-//                            Either::B(ok(()))
-//                        }
-//                    });
-//                    self.handle.spawn(approve_future);
-//                }
-//            }
-//        };
-//        Ok(())
-//    }
-//}
-//
-//impl<T: DuplexTransport + 'static> Future for ProcessTransfer<T> {
-//    type Item = ();
-//    type Error = ();
-//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//        loop {
-//            let transfer = try_ready!(self.rx.poll());
-//            match transfer {
-//                Some(t) => {
-//                    let value = {
-//                        let lock = self.target.pending.read().map_err(|e| {
-//                            error!("Failed to acquire read lock {:?}", e);
-//                        })?;
-//
-//                        lock.peek(&t.tx_hash).copied()
-//                    };
-//                    self.advance_transfer_approval(t, value).map_err(|e| {
-//                        error!("Failed to acquire write lock {:?}", e);
-//                    })?;
-//                }
-//                None => {
-//                    return Ok(Async::Ready(()));
-//                }
-//            };
-//        }
-//    }
-//}
-//
-//pub struct IsContract<T: DuplexTransport + 'static> {
-//    source: Network<T>,
-//    address: Address,
-//    future: Vec<U256>,
-//}
-//
-//impl<T: DuplexTransport + 'static> IsContract<T> {
-//    pub fn new(source: &Network<T>, wallet: &Address) {
-//        // Get contract data
-//    }
-//}
-//
-//impl<T: DuplexTransport + 'static> Future for IsContract<T> {
-//    type Item = bool;
-//    type Error = ();
-//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//        let bytes = try_ready!(self.future.poll());
-//        Ok(Async::Ready(bytes == "0x"))
-//    }
-//}
-//
-//pub enum BalanceCheckState {
-//    GetEndingBlock(Box<Future<Item = U256, Error = ()>>),
-//    GetLogWindow(u64, u64, Box<Future<Item = Vec<Log>, Error = ()>>),
-//}
-//
-//pub struct BalanceCheck<T: DuplexTransport + 'static> {
-//    source: Network<T>,
-//    state: BalanceCheckState,
-//    tx: mpsc::UnboundedSender<Result<BalanceResponse, ()>>,
-//    balances: HashMap<Address, U256>,
-//    start: Instant,
-//}
-//
-//impl<T: DuplexTransport + 'static> BalanceCheck<T> {
-//    fn new(source: &Network<T>, tx: &mpsc::UnboundedSender<Result<BalanceResponse, ()>>) -> Self {
-//        let future = source.web3.eth().block_number().map_err(move |e| {
-//            error!("error getting block number {:?}", e);
-//        });
-//
-//        BalanceCheck {
-//            source: source.clone(),
-//            tx: tx.clone(),
-//            state: BalanceCheckState::GetEndingBlock(Box::new(future)),
-//            balances: HashMap::new(),
-//            start: Instant::now(),
-//        }
-//    }
-//
-//    fn build_next_window(&self, start: u64, end: u64) -> Box<Future<Item = Vec<Log>, Error = ()>> {
-//        let token_address: Address = self.source.token.address();
-//        let filter = FilterBuilder::default()
-//            .address(vec![token_address])
-//            .from_block(BlockNumber::from(start))
-//            .to_block(BlockNumber::Number(end))
-//            .topics(Some(vec![TRANSFER_EVENT_SIGNATURE.into()]), None, None, None)
-//            .build();
-//        //self.state = ;
-//        let future = self.source.web3.eth().logs(filter).map_err(move |e| {
-//            error!("error getting block number {:?}", e);
-//        });
-//        Box::new(future)
-//    }
-//}
-//
-//impl<T: DuplexTransport + 'static> Future for BalanceCheck<T> {
-//    type Item = ();
-//    type Error = ();
-//    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//        loop {
-//            let tx = self.tx.clone();
-//            let next = match self.state {
-//                BalanceCheckState::GetEndingBlock(ref mut future) => {
-//                    let block = try_ready!(future.poll());
-//                    let window_end = cmp::min(block.as_u64(), 1000);
-//                    let future = self.build_next_window(0, window_end);
-//                    BalanceCheckState::GetLogWindow(block.as_u64(), window_end, future)
-//                }
-//                BalanceCheckState::GetLogWindow(end, window_end, ref mut future) => {
-//                    let logs = try_ready!(future.poll());
-//                    info!(
-//                        "found {} logs with transfers between {} and {}",
-//                        logs.len(),
-//                        window_end,
-//                        end
-//                    );
-//                    // Process existing logs
-//                    logs.iter().for_each(|log| {
-//                        if Some(true) == log.removed {
-//                            return;
-//                        }
-//
-//                        let sender_address: Address = log.topics[1].into();
-//                        let receiver_address: Address = log.topics[2].into();
-//                        let amount: U256 = log.data.0[..32].into();
-//                        debug!("{} transferred {} to {}", sender_address, amount, receiver_address);
-//                        // Don't care if source doesn't exist, because it is likely a mint in that case
-//                        let zero = U256::zero();
-//                        self.balances
-//                            .entry(sender_address)
-//                            .and_modify(|v| {
-//                                if !v.is_zero() {
-//                                    *v -= amount;
-//                                }
-//                            })
-//                            .or_insert(zero);
-//                        let dest_balance = self.balances.entry(receiver_address).or_insert(zero);
-//                        *dest_balance += amount;
-//                    });
-//
-//                    debug!("Window end is {} of {} blocks", window_end, end);
-//                    // Setup next window
-//                    if window_end < end {
-//                        let next_window_end = cmp::min(end, window_end + 1000);
-//                        let future = self.build_next_window(window_end + 1, next_window_end);
-//                        BalanceCheckState::GetLogWindow(end, next_window_end, future)
-//                    } else {
-//                        let send_result = tx.unbounded_send(Ok(BalanceResponse::new(
-//                            &Instant::now().duration_since(self.start),
-//                            &self.balances.clone(),
-//                        )));
-//                        if send_result.is_err() {
-//                            error!("error sending balance response");
-//                        }
-//                        return Ok(Async::Ready(()));
-//                    }
-//                }
-//            };
-//            self.state = next;
-//        }
-//    }
-//}
+use eth::contracts::{FLUSH_EVENT_SIGNATURE, TRANSFER_EVENT_SIGNATURE};
+use ethabi::Token;
+use extensions::removed::{CancelRemoved, ExitOnLogRemoved};
+use extensions::timeout::SubscriptionState;
+use lru::LruCache;
+use relay::{Network, NetworkType, TransferApprovalState};
+use relay_config::logger::flush;
+use server::handler::{BalanceOf, BalanceQuery};
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::{PoisonError, RwLockWriteGuard};
+use std::time::Instant;
+use std::{cmp, time};
+use tokio::sync::mpsc;
+use tokio_core::reactor;
+use transfers::transfer::Transfer;
+use web3::confirm::{wait_for_transaction_confirmation, SendTransactionWithConfirmation};
+use web3::contract::tokens::{Detokenize, Tokenize};
+use web3::contract::{ErrorKind, QueryResult};
+use web3::futures::prelude::*;
+use web3::futures::try_ready;
+use web3::types::{Address, BlockNumber, Bytes, FilterBuilder, Log, Transaction, TransactionReceipt, H256, U256};
+use web3::{contract, DuplexTransport};
+
+enum ProcessFlushState<T: DuplexTransport + 'static> {
+    Wait,
+    CheckBalances(CheckBalances<T>),
+    FilterContracts(FilterContracts),
+    FilterLowBalance(FilterLowBalance),
+    WithdrawWallets(Box<Future<Item = Vec<()>, Error = ()>>),
+    WithdrawLeftovers(Box<Future<Item = (), Error = ()>>),
+}
+
+pub struct ProcessFlush<T: DuplexTransport + 'static> {
+    rx: mpsc::UnboundedReceiver<(Log, TransactionReceipt)>,
+    handle: reactor::Handle,
+    source: Network<T>,
+    target: Network<T>,
+    flush_receipt: Option<TransactionReceipt>,
+}
+
+impl<T: DuplexTransport + 'static> ProcessFlush<T> {
+    pub fn new(
+        source: &Network<T>,
+        target: &Network<T>,
+        rx: mpsc::UnboundedReceiver<(Log, TransactionReceipt)>,
+        handle: &reactor::Handle,
+    ) -> Self {
+        ProcessFlush {
+            rx,
+            source: source.clone(),
+            target: target.clone(),
+            handle: handle.clone(),
+            flush_receipt: None,
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for ProcessFlush<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let network_type = self.source.network_type;
+        let target = self.target.clone();
+        let source = self.source.clone();
+        loop {
+            let flush_receipt = self.flush_receipt.clone();
+            let next: ProcessFlushState<T> = match self.state {
+                ProcessFlushState::Wait => {
+                    let event = try_ready!(self.rx.poll());
+                    match event {
+                        Some((log, receipt)) => {
+                            let removed = log.removed.unwrap_or(false);
+                            if !removed {
+                                if receipt.block_hash.is_none() {
+                                    error!("Failed to get block hash for flush");
+                                    return Err(());
+                                }
+
+                                if receipt.block_number.is_none() {
+                                    error!("Failed to get block hash for flush");
+                                    return Err(());
+                                }
+
+                                self.flush_receipt = Some(receipt);
+                                let balance_future = CheckBalances::new(&source, receipt.block_number);
+                                ProcessFlushState::CheckingBalances(balance_future)
+                            }
+                        }
+                        None => {
+                            return Ok(Async::Ready(()));
+                        }
+                    }
+                }
+                ProcessFlushState::CheckBalances(ref mut future) => {
+                    let balances = try_ready!(future.poll());
+                    let contract_future = FilterContracts::new(&source, balances);
+                    ProcessFlushState::FilterContracts(contract_future)
+                }
+                ProcessFlushState::FilterContracts(ref mut future) => {
+                    let balances = try_ready!(future.poll());
+                    let low_balance_future = FilterLowBalance::new(&target, balances);
+                    ProcessFlushState::FilterLowBalance(low_balance_future)
+                }
+                ProcessFlushState::FilterLowBalance(ref mut future) => {
+                    let balances = try_ready!(future.poll());
+                    match flush_receipt {
+                        Some(receipt) => {
+                            let futures = join_all(balances.iter().map(|(address, balance)| {
+                                let transfer =
+                                    Transfer::from_receipt(address, balances, false, &receipt).map_err(|e| {
+                                        error!("Error creating transaction from flush receipt: {:?}", e);
+                                        return Err(());
+                                    })?;
+                                transfer.approve_withdrawal(&source, &target)
+                                // make transfer
+                                // approve transfer on target
+                            }));
+                            ProcessFlushState::WithdrawWallets(Box::new(futures))
+                        }
+                        None => {
+                            error!("No flush receipt available");
+                            return Err(());
+                        }
+                    }
+                }
+                ProcessFlushState::WithdrawWallets(ref mut future) => {
+                    try_ready!(future.poll());
+                    match flush_receipt {
+                        Some(receipt) => {
+                            ProcessFlushState::WithdrawLeftovers(WithdrawLeftovers::new(&source, &target, &receipt))
+                        }
+                        None => {
+                            error!("No flush receipt available");
+                            return Err(());
+                        }
+                    }
+                }
+                ProcessFlushState::WithdrawLeftovers(ref mut future) => {
+                    try_ready!(future.poll());
+                    critical!("finished flush");
+                    return Ok(Async::Ready(()));
+                }
+            };
+            self.state = next;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FeeWallet(Address);
+
+impl Detokenize for FeeWallet {
+    /// Creates a new instance from parsed ABI tokens.
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self, contract::Error>
+    where
+        Self: Sized,
+    {
+        let fee_wallet = tokens[0].clone().to_address().ok_or_else(|| {
+            contract::Error::from_kind(contract::ErrorKind::Msg(
+                "cannot parse fee wallet from contract response".to_string(),
+            ))
+        })?;
+        debug!("fees wallet: {:?}", fee_wallet);
+        Ok(FeeWallet(fee_wallet))
+    }
+}
+
+pub struct FeeWalletQuery {}
+
+impl FeeWalletQuery {
+    fn new() -> Self {
+        FeeWalletQuery {}
+    }
+}
+
+impl Tokenize for FeeWalletQuery {
+    fn into_tokens(self) -> Vec<Token> {
+        vec![]
+    }
+}
+
+enum WithdrawLeftoversState {
+    GetBalance(Box<Future<Item = U256, Error = ()>>),
+    GetFeeWallet(Box<Future<Item = Address, Error = ()>>),
+    Withdraw(Box<Future<Item = (), Error = ()>>),
+}
+
+pub struct WithdrawLeftovers<T: DuplexTransport + 'static> {
+    state: WithdrawLeftoversState,
+    source: Network<T>,
+    target: Network<T>,
+    receipt: TransactionReceipt,
+    balance: Option<U256>,
+    fee_wallet: Option<Address>,
+}
+
+impl<T: DuplexTransport + 'static> WithdrawLeftovers<T> {
+    fn new(source: &Network<T>, target: &Network<T>, flush_receipt: &TransactionReceipt) {
+        let state = WithdrawLeftoversState::GetFeeWallet(WithdrawLeftovers::get_balance(&target));
+        WithdrawLeftovers {
+            state,
+            source: source.clone(),
+            target: target.clone(),
+            receipt: receipt.clone(),
+            balance: None,
+            fee_wallet: None,
+        }
+    }
+
+    fn get_balance(target: &Network<T>) -> Box<Future<Item = U256, Error = ()>> {
+        let relay_contract_balance_query = BalanceQuery::new(target.relay.address());
+        let target = target.clone();
+        Box::new(
+            target
+                .token
+                .query::<BalanceOf, Address, BlockNumber, BalanceQuery>(
+                    "balanceOf",
+                    relay_contract_balance_query,
+                    target.account,
+                    Options::default(),
+                    BlockNumber::Latest,
+                )
+                .map_err(|e| {
+                    error!("error retrieving contract balance: {:?}", e);
+                    ()
+                }),
+        )
+    }
+
+    fn get_fee_wallet(target: &Network<T>) -> Box<Future<Item = Address, Error = ()>> {
+        let fee_wallet_query = FeeWalletQuery::new();
+        let target = target.clone();
+        Box::new(
+            target
+                .token
+                .query::<FeeWallet, Address, BlockNumber, FeeWalletQuery>(
+                    "feeWallet",
+                    fee_wallet_query,
+                    target.account,
+                    Options::default(),
+                    BlockNumber::Latest,
+                )
+                .map_err(|e| {
+                    error!("error retrieving fee wallet: {:?}", e);
+                    ()
+                }),
+        )
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for WithdrawLeftovers<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let source = self.source.clone();
+            let target = self.target.clone();
+            let receipt = self.receipt.clone();
+            let next = match self.state {
+                WithdrawLeftoversState::GetBalance(ref mut future) => {
+                    let balance = try_ready!(future.poll());
+                    self.balance = Some(balance.0);
+                    WithdrawLeftoversState::GetFeeWallet(WithdrawLeftovers::get_fee_wallet(&target))
+                }
+                WithdrawLeftoversState::GetFeeWallet(ref mut future) => {
+                    let address = try_ready!(future.poll());
+                    let transfer = Transfer::from_receipt(address.0, balances, false, &receipt).map_err(|e| {
+                        error!("Error creating transaction from flush receipt: {:?}", e);
+                        return Err(());
+                    })?;
+                    WithdrawLeftoversState::Withdraw(transfer.approve_withdrawal(&source, &target))
+                }
+                WithdrawLeftoversState::Withdraw(ref mut future) => {
+                    try_ready!(future.poll());
+                    return Ok(Async::Ready(()));
+                }
+            };
+            self.state = next;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Fees(U256);
+
+impl Detokenize for Fees {
+    /// Creates a new instance from parsed ABI tokens.
+    fn from_tokens(tokens: Vec<Token>) -> Result<Self, contract::Error>
+    where
+        Self: Sized,
+    {
+        let fee = tokens[0].clone().to_uint().ok_or_else(|| {
+            contract::Error::from_kind(contract::ErrorKind::Msg(
+                "cannot parse fees from contract response".to_string(),
+            ))
+        })?;
+        debug!("fees: {:?}", fee);
+        Ok(Fees(fee))
+    }
+}
+
+pub struct FeeQuery {}
+
+impl FeeQuery {
+    fn new() -> Self {
+        FeeQuery {}
+    }
+}
+
+impl Tokenize for FeeQuery {
+    fn into_tokens(self) -> Vec<Token> {
+        vec![]
+    }
+}
+
+pub struct FilterLowBalance {
+    future: Box<Future<Item = U256, Error = ()>>,
+    wallets: Vec<(Address, U256)>,
+}
+
+impl FilterLowBalance {
+    pub fn new<T: DuplexTransport + 'static>(target: &Network<T>, wallets: Vec<(Address, U256)>) -> Self {
+        // Get contract data
+        let futures = target.relay.query::<Fees, Address, BlockNumber, FeeQuery>(
+            "fees",
+            FeeQuery::new(),
+            target.account.clone(),
+            Options::default(),
+            BlockNumber::Latest,
+        );
+
+        FilterLowBalance {
+            future: Box::new(future),
+            wallets: wallets.clone(),
+        }
+    }
+}
+
+impl Future for FilterLowBalance {
+    type Item = Vec<(Address, U256)>;
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let fee = try_ready!(self.future.poll());
+        self.balances.iter().filter(|(address, balance)| balance > fee)
+    }
+}
+
+pub struct FilterContracts {
+    future: Box<Future<Item = Vec<Bytes>, Error = ()>>,
+    wallets: Vec<(Address, U256)>,
+}
+
+impl FilterContracts {
+    pub fn new<T: DuplexTransport + 'static>(source: &Network<T>, wallets: Vec<(Address, U256)>) -> Self {
+        // Get contract data
+        let futures = join_all(
+            wallets
+                .iter()
+                .map(|(address, balance)| source.web3.eth().code(wallet, None)),
+        )
+        .map_err(move |e| {
+            error!("error getting bytes for wallets: {:?}", e);
+        });
+
+        FilterContracts {
+            future: Box::new(futures),
+            wallets: wallets.clone(),
+        }
+    }
+}
+
+impl Future for FilterContracts {
+    type Item = Vec<(Address, U256)>;
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let all_bytes = try_ready!(self.future.poll());
+        all_bytes.iter().zip(self.balances).filter_map(
+            move |(bytes, (addr, balance))| {
+                if bytes.len() == 0 {
+                    Some((addr, balance))
+                } else {
+                    None
+                }
+            },
+        )
+    }
+}
+
+pub enum CheckBalancesState {
+    GetEndingBlock(Box<Future<Item = U256, Error = ()>>),
+    GetLogWindow(u64, u64, Box<Future<Item = Vec<Log>, Error = ()>>),
+}
+
+pub struct CheckBalances<T: DuplexTransport + 'static> {
+    source: Network<T>,
+    state: CheckBalancesState,
+    balances: HashMap<Address, U256>,
+}
+
+impl<T: DuplexTransport + 'static> CheckBalances<T> {
+    fn new(source: &Network<T>, block: Option<U256>) -> Self {
+        let state = match block {
+            Some(b) => {
+                let window_end = cmp::min(block.as_u64(), 1000);
+                CheckBalancesState::GetLogWindow(
+                    block.as_u64(),
+                    window_end,
+                    balances.build_next_window(source, 0, window_end),
+                )
+            }
+            None => {
+                let future = source.web3.eth().block_number().map_err(move |e| {
+                    error!("error getting block number {:?}", e);
+                });
+                CheckBalancesState::GetEndingBlock(future)
+            }
+        };
+        CheckBalances {
+            source: source.clone(),
+            state,
+            balances: HashMap::new(),
+        }
+    }
+
+    fn build_next_window(source: &Network<T>, start: u64, end: u64) -> Box<Future<Item = Vec<Log>, Error = ()>> {
+        let token_address: Address = source.token.address();
+        let filter = FilterBuilder::default()
+            .address(vec![token_address])
+            .from_block(BlockNumber::from(start))
+            .to_block(BlockNumber::Number(end))
+            .topics(Some(vec![TRANSFER_EVENT_SIGNATURE.into()]), None, None, None)
+            .build();
+        //self.state = ;
+        let future = source.web3.eth().logs(filter).map_err(move |e| {
+            error!("error getting block number {:?}", e);
+        });
+        Box::new(future)
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for CheckBalances<T> {
+    type Item = Vec<(Address, U256)>;
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let source = self.source.clone();
+        loop {
+            let next = match self.state {
+                BalanceCheckState::GetEndingBlock(ref mut future) => {
+                    let block = try_ready!(future.poll());
+                    let window_end = cmp::min(block.as_u64(), 1000);
+                    let future = CheckBalances::build_next_window(&source, 0, window_end);
+                    BalanceCheckState::GetLogWindow(block.as_u64(), window_end, future)
+                }
+                CheckBalancesState::GetLogWindow(end, window_end, ref mut future) => {
+                    let logs = try_ready!(future.poll());
+                    info!(
+                        "found {} logs with transfers between {} and {}",
+                        logs.len(),
+                        window_end,
+                        end
+                    );
+                    // Process existing logs
+                    logs.iter().for_each(|log| {
+                        if Some(true) != log.removed {
+                            let sender_address: Address = log.topics[1].into();
+                            let receiver_address: Address = log.topics[2].into();
+                            let amount: U256 = log.data.0[..32].into();
+                            debug!("{} transferred {} to {}", sender_address, amount, receiver_address);
+                            // Don't care if source doesn't exist, because it is likely a mint in that case
+                            let zero = U256::zero();
+                            self.balances
+                                .entry(sender_address)
+                                .and_modify(|v| {
+                                    if !v.is_zero() {
+                                        *v -= amount;
+                                    }
+                                })
+                                .or_insert(zero);
+                            let dest_balance = self.balances.entry(receiver_address).or_insert(zero);
+                            *dest_balance += amount;
+                        }
+                    });
+
+                    debug!("Window end is {} of {} blocks", window_end, end);
+                    // Setup next window
+                    if window_end < end {
+                        let next_window_end = cmp::min(end, window_end + 1000);
+                        let future = CheckBalances::build_next_window(&source, window_end + 1, next_window_end);
+                        CheckBalancesState::GetLogWindow(end, next_window_end, future)
+                    } else {
+                        return Ok(Async::Ready(self.balances.into_iter().collect()));
+                    }
+                }
+            };
+            self.state = next;
+        }
+    }
+}

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -16,8 +16,8 @@ use super::extensions::timeout::SubscriptionState;
 use super::relay::{Network, NetworkType, TransferApprovalState};
 use super::transfers::transfer::Transfer;
 
-/// Stream of transfer events that have been on the main chain for N blocks.
-/// N is confirmations per settings.
+/// Stream of events that have match the given filter.
+/// Passes the transaction receipt and log over the given tx upon confirmation (or removal)
 pub struct WatchLiveLogs<T: DuplexTransport + 'static> {
     // TODO Add the desired event signature & change name to just WatchLogs
     state: SubscriptionState<T, Log>,
@@ -33,7 +33,7 @@ impl<T: DuplexTransport + 'static> WatchLiveLogs<T> {
     /// # Arguments
     ///
     /// * `source` - Network where the transfers are performed
-    /// * `handle` - Handle to spawn naew futures
+    /// * `handle` - Handle to spawn new futures
     pub fn new(
         source: &Network<T>,
         target: &Network<T>,
@@ -128,6 +128,8 @@ impl<T: DuplexTransport + 'static> Future for WatchLiveLogs<T> {
     }
 }
 
+/// Process logs/receipt for Transfer events seen on the chain
+/// Tracks the state of the transfer and triggers a withdrawal (or unwithdrawal on removal) on the target chain
 pub struct ProcessTransfer<T: DuplexTransport + 'static> {
     rx: mpsc::UnboundedReceiver<(Log, TransactionReceipt)>,
     handle: reactor::Handle,

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -8,7 +8,7 @@ use web3::futures::future::{err, ok, Either, Future};
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
 use web3::futures::try_ready;
-use web3::types::{Address, FilterBuilder, Log, TransactionReceipt, H256, U256};
+use web3::types::{Address, Filter, FilterBuilder, Log, TransactionReceipt, H256, U256};
 use web3::{DuplexTransport, ErrorKind};
 
 use super::extensions::removed::{CancelRemoved, ExitOnLogRemoved};
@@ -37,21 +37,11 @@ impl<T: DuplexTransport + 'static> WatchLiveLogs<T> {
     pub fn new(
         source: &Network<T>,
         target: &Network<T>,
-        event_signature: &'static str,
+        filter: &Filter,
         tx: &mpsc::UnboundedSender<(Log, TransactionReceipt)>,
         handle: &reactor::Handle,
     ) -> Self {
-        let filter = FilterBuilder::default()
-            .address(vec![source.token.address()])
-            .topics(
-                Some(vec![event_signature.into()]),
-                None,
-                Some(vec![source.relay.address().into()]),
-                None,
-            )
-            .build();
-
-        let future = Box::new(source.web3.clone().eth_subscribe().subscribe_logs(filter));
+        let future = Box::new(source.web3.clone().eth_subscribe().subscribe_logs(filter.clone()));
 
         WatchLiveLogs {
             source: source.clone(),

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -154,7 +154,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                         .pending
                         .write()?
                         .put(transfer.tx_hash, TransferApprovalState::Removed);
-                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target));
+                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target, true));
                 }
             }
             Some(TransferApprovalState::Removed) => {
@@ -165,7 +165,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                         .write()?
                         .put(transfer.tx_hash, TransferApprovalState::Sent);
                     self.handle
-                        .spawn(transfer.approve_withdrawal(&self.source, &self.target));
+                        .spawn(transfer.approve_withdrawal(&self.source, &self.target, true));
                 }
             }
             None => {
@@ -179,7 +179,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                     let target = self.target.clone();
                     let unapprove_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
                         if !not_approved {
-                            Either::A(transfer.unapprove_withdrawal(&target))
+                            Either::A(transfer.unapprove_withdrawal(&target, true))
                         } else {
                             Either::B(ok(()))
                         }
@@ -196,7 +196,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                     let target = self.target.clone();
                     let approve_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
                         if not_approved {
-                            Either::A(transfer.approve_withdrawal(&source, &target))
+                            Either::A(transfer.approve_withdrawal(&source, &target, true))
                         } else {
                             Either::B(ok(()))
                         }

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -154,7 +154,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                         .pending
                         .write()?
                         .put(transfer.tx_hash, TransferApprovalState::Removed);
-                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target, true));
+                    self.handle.spawn(transfer.unapprove_withdrawal(&self.target));
                 }
             }
             Some(TransferApprovalState::Removed) => {
@@ -165,7 +165,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                         .write()?
                         .put(transfer.tx_hash, TransferApprovalState::Sent);
                     self.handle
-                        .spawn(transfer.approve_withdrawal(&self.source, &self.target, true));
+                        .spawn(transfer.approve_withdrawal(&self.source, &self.target));
                 }
             }
             None => {
@@ -179,7 +179,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                     let target = self.target.clone();
                     let unapprove_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
                         if !not_approved {
-                            Either::A(transfer.unapprove_withdrawal(&target, true))
+                            Either::A(transfer.unapprove_withdrawal(&target))
                         } else {
                             Either::B(ok(()))
                         }
@@ -196,7 +196,7 @@ impl<T: DuplexTransport + 'static> ProcessTransfer<T> {
                     let target = self.target.clone();
                     let approve_future = transfer.check_withdrawal(&self.target).and_then(move |not_approved| {
                         if not_approved {
-                            Either::A(transfer.approve_withdrawal(&source, &target, true))
+                            Either::A(transfer.approve_withdrawal(&source, &target))
                         } else {
                             Either::B(ok(()))
                         }

--- a/src/transfers/mod.rs
+++ b/src/transfers/mod.rs
@@ -1,3 +1,4 @@
+pub mod flush;
 pub mod live;
 pub mod past;
 pub mod transfer;

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -267,7 +267,7 @@ impl<T: DuplexTransport + 'static> Future for ValidateAndApproveTransfer<T> {
                 "approving missed transfer on {:?}: {:?}",
                 target.network_type, self.transfer
             );
-            handle.spawn(self.transfer.approve_withdrawal(&source, &target));
+            handle.spawn(self.transfer.approve_withdrawal(&source, &target, true));
         }
         Ok(Async::Ready(()))
     }

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -267,7 +267,7 @@ impl<T: DuplexTransport + 'static> Future for ValidateAndApproveTransfer<T> {
                 "approving missed transfer on {:?}: {:?}",
                 target.network_type, self.transfer
             );
-            handle.spawn(self.transfer.approve_withdrawal(&source, &target, true));
+            handle.spawn(self.transfer.approve_withdrawal(&source, &target));
         }
         Ok(Async::Ready(()))
     }

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -194,7 +194,7 @@ impl RecheckPastTransferLogs {
     /// * `handle` - Handle to spawn new futures
     pub fn new<T: DuplexTransport + 'static>(
         source: &Network<T>,
-        target: &Rc<Network<T>>,
+        target: &Network<T>,
         handle: &reactor::Handle,
     ) -> Self {
         let handle = handle.clone();
@@ -223,7 +223,7 @@ impl Future for RecheckPastTransferLogs {
 
 /// Future to check a transfer against the contract and approve is necessary
 pub struct ValidateAndApproveTransfer<T: DuplexTransport + 'static> {
-    target: Rc<Network<T>>,
+    target: Network<T>,
     handle: reactor::Handle,
     transfer: Transfer,
     future: Box<Future<Item = bool, Error = ()>>,
@@ -237,7 +237,7 @@ impl<T: DuplexTransport + 'static> ValidateAndApproveTransfer<T> {
     /// * `target` - Network where the transfer will be approved for a withdrawal
     /// * `handle` - Handle to spawn new futures
     /// * `transfer` - Transfer event to check/approve
-    pub fn new(target: &Rc<Network<T>>, handle: &reactor::Handle, transfer: &Transfer) -> Self {
+    pub fn new(target: &Network<T>, handle: &reactor::Handle, transfer: &Transfer) -> Self {
         let network_type = target.network_type;
         let future = transfer.check_withdrawal(&target).map_err(move |e| {
             error!("error checking withdrawal for approval on {:?}: {:?}", network_type, e);
@@ -278,7 +278,7 @@ pub enum FindTransferState {
 /// Future to find a vec of transfers at a specific transaction
 pub struct FindTransferInTransaction<T: DuplexTransport + 'static> {
     hash: H256,
-    source: Rc<Network<T>>,
+    source: Network<T>,
     state: FindTransferState,
 }
 
@@ -289,7 +289,7 @@ impl<T: DuplexTransport + 'static> FindTransferInTransaction<T> {
     ///
     /// * `source` - Network where the transaction took place
     /// * `hash` - Transaction hash to check
-    pub fn new(source: &Rc<Network<T>>, hash: &H256) -> Self {
+    pub fn new(source: &Network<T>, hash: &H256) -> Self {
         let web3 = source.web3.clone();
         let network_type = source.network_type;
         let future = web3.clone().eth().transaction_receipt(*hash).map_err(move |e| {

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -4,7 +4,7 @@ use web3::futures::future;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
 use web3::futures::try_ready;
-use web3::types::{Address, BlockNumber, FilterBuilder, U256};
+use web3::types::{Address, BlockNumber, FilterBuilder, TransactionReceipt, H256, U256};
 use web3::{DuplexTransport, ErrorKind};
 
 use super::eth::contracts::TRANSFER_EVENT_SIGNATURE;
@@ -267,5 +267,132 @@ impl<T: DuplexTransport + 'static> Future for ValidateAndApproveTransfer<T> {
             handle.spawn(self.transfer.approve_withdrawal(&target));
         }
         Ok(Async::Ready(()))
+    }
+}
+
+pub enum FindTransferState {
+    ExtractTransfers(Box<Future<Item = Vec<Transfer>, Error = ()>>),
+    FetchReceipt(Box<Future<Item = Option<TransactionReceipt>, Error = ()>>),
+}
+
+/// Future to find a vec of transfers at a specific transaction
+pub struct FindTransferInTransaction<T: DuplexTransport + 'static> {
+    hash: H256,
+    source: Rc<Network<T>>,
+    state: FindTransferState,
+}
+
+impl<T: DuplexTransport + 'static> FindTransferInTransaction<T> {
+    /// Returns a newly created FindTransferInTransaction Future
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - Network where the transaction took place
+    /// * `hash` - Transaction hash to check
+    pub fn new(source: &Rc<Network<T>>, hash: &H256) -> Self {
+        let web3 = source.web3.clone();
+        let network_type = source.network_type;
+        let future = web3.clone().eth().transaction_receipt(*hash).map_err(move |e| {
+            error!("error getting transaction receipt on {:?}: {:?}", network_type, e);
+        });
+        let state = FindTransferState::FetchReceipt(Box::new(future));
+        FindTransferInTransaction {
+            hash: *hash,
+            source: source.clone(),
+            state,
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for FindTransferInTransaction<T> {
+    type Item = Vec<Transfer>;
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let source = self.source.clone();
+            let network_type = source.network_type;
+            let hash = self.hash;
+            let next = match self.state {
+                FindTransferState::ExtractTransfers(ref mut future) => {
+                    let transfers = try_ready!(future.poll());
+                    if transfers.is_empty() {
+                        warn!("no relay transactions found on {:?} at {:?}", network_type, hash);
+                        return Err(());
+                    } else {
+                        return Ok(Async::Ready(transfers));
+                    }
+                }
+                FindTransferState::FetchReceipt(ref mut future) => {
+                    let receipt = try_ready!(future.poll());
+                    match receipt {
+                        Some(r) => {
+                            if r.block_hash.is_none() {
+                                error!("receipt did not have block hash on {:?}", network_type);
+                                return Err(());
+                            }
+                            let block_hash = r.block_hash.unwrap();
+                            r.block_number.map_or_else(
+                                || {
+                                    error!("receipt did not have block number on {:?}", network_type);
+                                    Err(())
+                                },
+                                |receipt_block| {
+                                    let future = source
+                                        .web3
+                                        .clone()
+                                        .eth()
+                                        .block_number()
+                                        .and_then(move |block| {
+                                            let mut transfers = Vec::new();
+                                            if let Some(confirmed) =
+                                                block.checked_rem(receipt_block).map(|u| u.as_u64())
+                                            {
+                                                if confirmed > source.confirmations {
+                                                    let logs = r.logs;
+                                                    for log in logs {
+                                                        info!(
+                                                            "found log at {:?} on {:?}: {:?}",
+                                                            hash, network_type, log
+                                                        );
+                                                        if log.topics[0] == TRANSFER_EVENT_SIGNATURE.into()
+                                                            && log.topics[2] == source.relay.address().into()
+                                                        {
+                                                            let destination: Address = log.topics[1].into();
+                                                            let amount: U256 = log.data.0[..32].into();
+                                                            if destination == Address::zero() {
+                                                                info!("found mint on {:?}. Skipping", network_type);
+                                                                continue;
+                                                            }
+                                                            let transfer = Transfer {
+                                                                destination,
+                                                                amount,
+                                                                tx_hash: hash,
+                                                                block_hash,
+                                                                block_number: receipt_block,
+                                                                removed: false,
+                                                            };
+                                                            transfers.push(transfer);
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            Ok(transfers)
+                                        })
+                                        .map_err(move |e| {
+                                            error!("error getting current block on {:?}: {:?}", network_type, e);
+                                        });
+                                    Ok(FindTransferState::ExtractTransfers(Box::new(future)))
+                                },
+                            )
+                        }
+                        None => {
+                            error!("unable to find {:?} on {:?}", hash, source.network_type);
+                            return Err(());
+                        }
+                    }?
+                }
+            };
+            self.state = next;
+        }
     }
 }

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use tokio_core::reactor;
 use web3::futures::future;
 use web3::futures::prelude::*;

--- a/src/transfers/transfer.rs
+++ b/src/transfers/transfer.rs
@@ -106,7 +106,8 @@ impl Transfer {
                 },
                 |_| Ok(()),
             )
-        }).or_else(|_| Ok(()));
+        })
+        .or_else(|_| Ok(()));
         Box::new(send)
     }
 
@@ -120,7 +121,8 @@ impl Transfer {
             "unapproveWithdrawal",
             &UnapproveParams::from(*self),
             target.retries,
-        ).or_else(|_| Ok(()));
+        )
+        .or_else(|_| Ok(()));
         Box::new(send)
     }
 }

--- a/src/transfers/transfer.rs
+++ b/src/transfers/transfer.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::rc::Rc;
 use web3::contract::tokens::Tokenize;
 use web3::futures::future::Future;
 use web3::types::{Address, TransactionReceipt, H256, U256};

--- a/src/transfers/transfer.rs
+++ b/src/transfers/transfer.rs
@@ -85,7 +85,6 @@ impl Transfer {
         &self,
         source: &Network<T>,
         target: &Network<T>,
-        ignore_errors: bool,
     ) -> Box<Future<Item = (), Error = ()>> {
         info!("approving withdrawal on {:?}: {} ", target.network_type, self);
         let target = target.clone();
@@ -107,18 +106,13 @@ impl Transfer {
                 },
                 |_| Ok(()),
             )
-        });
-        if ignore_errors {
-            Box::new(send.or_else(|_| Ok(())))
-        } else {
-            Box::new(send)
-        }
+        }).or_else(|_| Ok(()));
+        Box::new(send)
     }
 
     pub fn unapprove_withdrawal<T: DuplexTransport + 'static>(
         &self,
         target: &Network<T>,
-        ignore_errors: bool,
     ) -> Box<Future<Item = (), Error = ()>> {
         info!("unapproving withdrawal on {:?}: {} ", target.network_type, self);
         let send = SendTransaction::new(
@@ -126,12 +120,8 @@ impl Transfer {
             "unapproveWithdrawal",
             &UnapproveParams::from(*self),
             target.retries,
-        );
-        if ignore_errors {
-            Box::new(send.or_else(|_| Ok(())))
-        } else {
-            Box::new(send)
-        }
+        ).or_else(|_| Ok(()));
+        Box::new(send)
     }
 }
 

--- a/src/transfers/transfer.rs
+++ b/src/transfers/transfer.rs
@@ -16,8 +16,8 @@ where
     T: DuplexTransport + 'static,
     P: Tokenize + Clone + 'static,
 {
-    fn cancel_removed(self, target: &Rc<Network<T>>, tx_hash: H256) -> ExitOnLogRemoved<T, (), ()> {
-        ExitOnLogRemoved::new(target.clone(), tx_hash, Box::new(self))
+    fn cancel_removed(self, target: &Network<T>, tx_hash: H256) -> ExitOnLogRemoved<T, (), ()> {
+        ExitOnLogRemoved::new(target, tx_hash, Box::new(self))
     }
 }
 
@@ -73,7 +73,7 @@ impl Transfer {
     /// # Arguments
     ///
     /// * `target` - Network that withdrawals are posted to
-    pub fn check_withdrawal<T: DuplexTransport + 'static>(&self, target: &Rc<Network<T>>) -> DoesRequireApproval<T> {
+    pub fn check_withdrawal<T: DuplexTransport + 'static>(&self, target: &Network<T>) -> DoesRequireApproval<T> {
         DoesRequireApproval::new(target, self)
     }
 
@@ -84,7 +84,7 @@ impl Transfer {
     /// * `target` - Network where the withdrawals is performed
     pub fn approve_withdrawal<T: DuplexTransport + 'static>(
         &self,
-        target: &Rc<Network<T>>,
+        target: &Network<T>,
     ) -> Box<Future<Item = (), Error = ()>> {
         info!("approving withdrawal on {:?}: {} ", target.network_type, self);
         let target = target.clone();
@@ -113,7 +113,7 @@ impl Transfer {
 
     pub fn unapprove_withdrawal<T: DuplexTransport + 'static>(
         &self,
-        target: &Rc<Network<T>>,
+        target: &Network<T>,
     ) -> SendTransaction<T, UnapproveParams> {
         info!("unapproving withdrawal on {:?}: {} ", target.network_type, self);
         SendTransaction::new(

--- a/src/transfers/transfer.rs
+++ b/src/transfers/transfer.rs
@@ -84,6 +84,7 @@ impl Transfer {
     /// * `target` - Network where the withdrawals is performed
     pub fn approve_withdrawal<T: DuplexTransport + 'static>(
         &self,
+        source: &Network<T>,
         target: &Network<T>,
     ) -> Box<Future<Item = (), Error = ()>> {
         info!("approving withdrawal on {:?}: {} ", target.network_type, self);
@@ -95,7 +96,7 @@ impl Transfer {
                 &ApproveParams::from(*self),
                 target.retries,
             )
-            .cancel_removed(&target, self.tx_hash)
+            .cancel_removed(&source, self.tx_hash)
             .and_then(move |success| {
                 success.map_or_else(
                     || {

--- a/src/transfers/withdrawal.rs
+++ b/src/transfers/withdrawal.rs
@@ -164,13 +164,13 @@ pub enum CheckWithdrawalState {
 
 /// Future to check whether or not a withdrawal needs approval
 pub struct DoesRequireApproval<T: DuplexTransport + 'static> {
-    target: Rc<Network<T>>,
+    target: Network<T>,
     transfer: Transfer,
     state: CheckWithdrawalState,
 }
 
 impl<T: DuplexTransport + 'static> DoesRequireApproval<T> {
-    pub fn new(target: &Rc<Network<T>>, transfer: &Transfer) -> Self {
+    pub fn new(target: &Network<T>, transfer: &Transfer) -> Self {
         let approval_hash = Self::get_withdrawal_hash(transfer);
         let account = target.account;
         let network_type = target.network_type;
@@ -270,7 +270,7 @@ impl<T: DuplexTransport + 'static> Future for DoesRequireApproval<T> {
 pub struct GetWithdrawalApprovals(Box<Future<Item = WithdrawalApprovals, Error = ()>>);
 
 impl GetWithdrawalApprovals {
-    pub fn new<T: DuplexTransport + 'static>(target: &Rc<Network<T>>, approval_hash: &H256, index: &U256) -> Self {
+    pub fn new<T: DuplexTransport + 'static>(target: &Network<T>, approval_hash: &H256, index: &U256) -> Self {
         let target = target.clone();
         let account = target.account;
         let network_type = target.network_type;

--- a/src/transfers/withdrawal.rs
+++ b/src/transfers/withdrawal.rs
@@ -1,5 +1,4 @@
 use ethabi::Token;
-use std::rc::Rc;
 use tiny_keccak::keccak256;
 use web3::contract;
 use web3::contract::tokens::{Detokenize, Tokenize};


### PR DESCRIPTION
The goal is to respond to the `Flush` in the ERC20 Relay contract and withdraw NCT balances to the same wallet on homechain. That way we can shutdown a community and restore NCT to the original owner without user interaction.

~So far, this just adds a route to the http endpoint to get all the balances. Testing to see if looking over the entire history is fast enough.~ Takes about 15 minutes on 8 million blocks, but it should only run once in the lifetime of a community.  

TODO:
- [x] Respond to Flush event
- [x] Send a withdrawal on homechain for all non-contract addrs
- [x] Check flush status on startup 