### PR TITLE
Stop all subscriptions on flush

### DIFF
--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -9,8 +9,8 @@ use web3::types::{BlockId, BlockNumber, H256, U64};
 use web3::DuplexTransport;
 
 use crate::eth::transaction::SendTransaction;
-use crate::extensions::timeout::Timeout;
 use crate::extensions::flushed::Flushed;
+use crate::extensions::timeout::Timeout;
 use crate::relay::Network;
 
 /// Represents a block on the sidechain to be anchored to the homechain
@@ -66,11 +66,7 @@ impl<T: DuplexTransport + 'static> HandleAnchors<T> {
         let handle = handle.clone();
         let target = target.clone();
         let stream = FindAnchors::new(&source, &handle);
-        HandleAnchors {
-            target,
-            stream,
-            handle,
-        }
+        HandleAnchors { target, stream, handle }
     }
 }
 
@@ -85,7 +81,7 @@ impl<T: DuplexTransport + 'static> Future for HandleAnchors<T> {
                     self.handle.spawn(a.process(&self.target));
                 }
                 None => {
-                    return Err(());
+                    return Ok(Async::Ready(()));
                 }
             };
         }
@@ -118,8 +114,8 @@ impl FindAnchors {
                 .web3
                 .eth_subscribe()
                 .subscribe_new_heads()
-                .timeout(timeout, &h)
                 .flushed(&flushed)
+                .timeout(timeout, &h)
                 .for_each(move |head| {
                     head.number.map_or_else(
                         || {

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -83,7 +83,7 @@ impl<T: DuplexTransport + 'static> Future for HandleAnchors<T> {
                 None => {
                     return Err(());
                 }
-            }
+            };
         }
     }
 }

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -65,8 +65,12 @@ impl<T: DuplexTransport + 'static> HandleAnchors<T> {
     pub fn new(source: &Network<T>, target: &Network<T>, handle: &reactor::Handle) -> Self {
         let handle = handle.clone();
         let target = target.clone();
-        let stream = FindAnchors::new(source, &handle);
-        HandleAnchors { target, stream, handle }
+        let stream = FindAnchors::new(&source, &handle);
+        HandleAnchors {
+            target,
+            stream,
+            handle,
+        }
     }
 }
 

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -10,6 +10,7 @@ use web3::DuplexTransport;
 
 use crate::eth::transaction::SendTransaction;
 use crate::extensions::timeout::Timeout;
+use crate::extensions::flushed::Flushed;
 use crate::relay::Network;
 
 /// Represents a block on the sidechain to be anchored to the homechain
@@ -107,12 +108,14 @@ impl FindAnchors {
             let handle = handle.clone();
             let web3 = source.web3.clone();
             let timeout = source.timeout;
+            let flushed = source.flushed.clone();
 
             source
                 .web3
                 .eth_subscribe()
                 .subscribe_new_heads()
                 .timeout(timeout, &h)
+                .flushed(&flushed)
                 .for_each(move |head| {
                     head.number.map_or_else(
                         || {

--- a/src/eth/event.rs
+++ b/src/eth/event.rs
@@ -1,0 +1,16 @@
+use web3::types::{TransactionReceipt, Log};
+
+#[derive(Clone)]
+pub struct Event {
+    pub log: Log,
+    pub receipt: TransactionReceipt,
+}
+
+impl Event {
+    pub fn new(log: &Log, receipt: &TransactionReceipt) -> Self {
+        Event {
+            log: log.clone(),
+            receipt: receipt.clone(),
+        }
+    }
+}

--- a/src/eth/event.rs
+++ b/src/eth/event.rs
@@ -1,4 +1,4 @@
-use web3::types::{TransactionReceipt, Log};
+use web3::types::{Log, TransactionReceipt};
 
 #[derive(Clone)]
 pub struct Event {

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -1,6 +1,6 @@
 pub mod contracts;
+pub mod event;
 pub mod transaction;
 pub mod utils;
-pub mod event;
 
 pub use event::Event;

--- a/src/eth/mod.rs
+++ b/src/eth/mod.rs
@@ -1,3 +1,6 @@
 pub mod contracts;
 pub mod transaction;
 pub mod utils;
+pub mod event;
+
+pub use event::Event;

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -97,7 +97,7 @@ where
     fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<T, I>;
 }
 
-/// Add Timeout trait to SubscriptionResult, which is returned by web3.eth_subscribe()
+/// Add Flushed trait to SubscriptionResult, which is returned by web3.eth_subscribe()
 impl<T, I> Flushed<T, I> for SubscriptionResult<T, I>
 where
     T: DuplexTransport + 'static,

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -16,7 +16,7 @@ where
     T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
-    Subscribing(Box<SubscriptionResult<T, I>>),
+    Subscribing(SubscriptionResult<T, I>),
     Subscribed(SubscriptionStream<T, I>),
 }
 
@@ -126,6 +126,6 @@ where
     I: serde::de::DeserializeOwned + 'static,
 {
     fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<T, I> {
-        FlushedStream::new(flushed, SubscriptionState::Subscribing(Box::new(self)))
+        FlushedStream::new(flushed, SubscriptionState::Subscribing(self))
     }
 }

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -1,0 +1,105 @@
+use serde;
+use std::sync::{Arc, RwLock};
+use web3::error::Error;
+use web3::futures::prelude::*;
+use web3::DuplexTransport;
+
+use super::timeout::TimeoutStream;
+use crate::transfers::live::Event;
+
+/// FlushedStream adds a timeout to an existing Stream.
+/// returns Err if too much time has passed since the last object from the stream
+pub struct FlushedStream<I>
+where
+    I: serde::de::DeserializeOwned + 'static,
+{
+    flushed: Arc<RwLock<Option<Event>>>,
+    stream: Box<dyn Stream<Item = I, Error=web3::Error>>,
+}
+
+impl<I> FlushedStream<I>
+where
+    I: serde::de::DeserializeOwned + 'static,
+{
+    /// Returns a newly created FlushedStream Stream
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - Boxed stream to timeout
+    /// * `duration` - Duration of time to trigger the timeout
+    /// * `handle` - Handle to create a reactor::Timeout Future
+    pub fn new(flushed: &Arc<RwLock<Option<Event>>>, stream: Box<dyn Stream<Item = I, Error=web3::Error>>) -> Self {
+        FlushedStream {
+            flushed: flushed.clone(),
+            stream
+        }
+    }
+}
+
+impl<I> Stream for FlushedStream<I>
+where
+    I: serde::de::DeserializeOwned + 'static,
+{
+    type Item = I;
+    type Error = web3::Error;
+
+    /// Returns Items from the stream, or Err if timed out
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            let flushed = self.flushed.clone();
+            match self.stream.poll() {
+                // If the stream does not have the next element, check the lock
+                Ok(Async::NotReady) => match flushed.read() {
+                    Ok(lock) => {
+                        if lock.is_some() {
+                            // End stream if locked
+                            return Ok(Async::Ready(None));
+                        } else {
+                            return Ok(Async::NotReady);
+                        }
+                    }
+                    Err(e) => {
+                        error!("error acquiring flush event lock: {:?}", e);
+                        return Err(Error::Internal);
+                    }
+                }
+                Ok(Async::Ready(Some(msg))) => {
+                    return Ok(Async::Ready(Some(msg)));
+                }
+                // Forward stream done
+                Ok(Async::Ready(None)) => {
+                    return Ok(Async::Ready(None));
+                }
+                // Forward errors
+                Err(e) => {
+                    return Err(e);
+                }
+            };
+        }
+    }
+}
+
+/// Trait to add to any Stream for creating a FlushedStream via timeout()
+pub trait Flushed<I>
+where
+    I: serde::de::DeserializeOwned + 'static,
+{
+    ///Returns a FlushedStream that wraps the existing stream
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - Existing Stream that this is added to. Consumes self.
+    /// * `duration` - Time in seconds to trigger a timeout
+    /// # `handle` - Tokio reactor::Handle for Creating Timeout Future
+    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I>;
+}
+
+impl<T, I> Flushed<I> for TimeoutStream<T, I>
+where
+    T: DuplexTransport + 'static,
+    I: serde::de::DeserializeOwned + 'static,
+{
+    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I> {
+        FlushedStream::new(flushed, Box::new(self))
+    }
+}

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -21,7 +21,7 @@ where
 }
 
 /// FlushedStream adds a flush check to an existing Stream.
-/// It exists and unsubscribes
+/// It exits and calls unsubscribe on original stream
 pub struct FlushedStream<T, I>
 where
     T: DuplexTransport + 'static,

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -6,7 +6,7 @@ use web3::DuplexTransport;
 use web3::api::SubscriptionStream;
 
 use super::timeout::TimeoutStream;
-use crate::transfers::live::Event;
+use crate::eth::Event;
 
 /// FlushedStream adds a timeout to an existing Stream.
 /// returns Err if too much time has passed since the last object from the stream

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -1,44 +1,58 @@
 use serde;
 use std::sync::{Arc, RwLock};
+use web3::api::{SubscriptionResult, SubscriptionStream};
 use web3::error::Error;
 use web3::futures::prelude::*;
+use web3::futures::try_ready;
 use web3::DuplexTransport;
-use web3::api::SubscriptionStream;
 
-use super::timeout::TimeoutStream;
 use crate::eth::Event;
 
-/// FlushedStream adds a timeout to an existing Stream.
-/// returns Err if too much time has passed since the last object from the stream
-pub struct FlushedStream<I>
+/// Enum for the two stages of subscribing to a timeout stream
+/// Subscribing holds a future that returns a TimeoutStream
+/// Subscribed holds a TimeoutStream
+pub enum SubscriptionState<T, I>
 where
+    T: DuplexTransport + 'static,
+    I: serde::de::DeserializeOwned + 'static,
+{
+    Subscribing(Box<SubscriptionResult<T, I>>),
+    Subscribed(SubscriptionStream<T, I>),
+}
+
+/// FlushedStream adds a flush check to an existing Stream.
+/// It exists and unsubscribes
+pub struct FlushedStream<T, I>
+where
+    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     flushed: Arc<RwLock<Option<Event>>>,
-    stream: Box<dyn Stream<Item = I, Error=web3::Error>>,
+    state: SubscriptionState<T, I>,
 }
 
-impl<I> FlushedStream<I>
+impl<T, I> FlushedStream<T, I>
 where
+    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     /// Returns a newly created FlushedStream Stream
     ///
     /// # Arguments
     ///
-    /// * `stream` - Boxed stream to timeout
-    /// * `duration` - Duration of time to trigger the timeout
-    /// * `handle` - Handle to create a reactor::Timeout Future
-    pub fn new(flushed: &Arc<RwLock<Option<Event>>>, stream: Box<dyn Stream<Item = I, Error=web3::Error>>) -> Self {
+    /// * `flushed` - Event marking the flush
+    /// * `state` - SubscriptionResult from eth_subscribe()
+    pub fn new(flushed: &Arc<RwLock<Option<Event>>>, state: SubscriptionState<T, I>) -> Self {
         FlushedStream {
             flushed: flushed.clone(),
-            stream
+            state,
         }
     }
 }
 
-impl<I> Stream for FlushedStream<I>
+impl<T, I> Stream for FlushedStream<T, I>
 where
+    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     type Item = I;
@@ -46,43 +60,54 @@ where
 
     /// Returns Items from the stream, or Err if timed out
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let flushed = self.flushed.clone();
         loop {
-            let flushed = self.flushed.clone();
-            match self.stream.poll() {
-                // If the stream does not have the next element, check the lock
-                Ok(Async::NotReady) => match flushed.read() {
-                    Ok(lock) => {
-                        if lock.is_some() {
-                            // End stream if locked
-                            return Ok(Async::Ready(None));
-                        } else {
-                            return Ok(Async::NotReady);
+            let next = match self.state {
+                SubscriptionState::Subscribing(ref mut future) => {
+                    let stream = try_ready!(future.poll());
+                    Some(SubscriptionState::Subscribed(stream))
+                }
+                SubscriptionState::Subscribed(ref mut stream) => match stream.poll() {
+                    // If the stream does not have the next element, check the lock
+                    Ok(Async::NotReady) => match flushed.read() {
+                        Ok(lock) => {
+                            if lock.is_some() {
+                                // End stream if locked
+                                return Ok(Async::Ready(None));
+                            } else {
+                                return Ok(Async::NotReady);
+                            }
                         }
+                        Err(e) => {
+                            error!("error acquiring flush event lock: {:?}", e);
+                            return Err(Error::Internal);
+                        }
+                    },
+                    Ok(Async::Ready(Some(msg))) => {
+                        return Ok(Async::Ready(Some(msg)));
                     }
+                    // Forward stream done
+                    Ok(Async::Ready(None)) => {
+                        return Ok(Async::Ready(None));
+                    }
+                    // Forward errors
                     Err(e) => {
-                        error!("error acquiring flush event lock: {:?}", e);
-                        return Err(Error::Internal);
+                        return Err(e);
                     }
-                }
-                Ok(Async::Ready(Some(msg))) => {
-                    return Ok(Async::Ready(Some(msg)));
-                }
-                // Forward stream done
-                Ok(Async::Ready(None)) => {
-                    return Ok(Async::Ready(None));
-                }
-                // Forward errors
-                Err(e) => {
-                    return Err(e);
-                }
+                },
             };
+            // If the Future finished, set the state to subscribed
+            if let Some(next_state) = next {
+                self.state = next_state;
+            }
         }
     }
 }
 
 /// Trait to add to any Stream for creating a FlushedStream via timeout()
-pub trait Flushed<I>
+pub trait Flushed<T, I>
 where
+    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     ///Returns a FlushedStream that wraps the existing stream
@@ -90,28 +115,17 @@ where
     /// # Arguments
     ///
     /// * `self` - Existing Stream that this is added to. Consumes self.
-    /// * `duration` - Time in seconds to trigger a timeout
-    /// # `handle` - Tokio reactor::Handle for Creating Timeout Future
-    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I>;
+    /// * `flsuhed` - Event that triggered flush
+    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<T, I>;
 }
 
-impl<T, I> Flushed<I> for TimeoutStream<T, I>
+/// Add Timeout trait to SubscriptionResult, which is returned by web3.eth_subscribe()
+impl<T, I> Flushed<T, I> for SubscriptionResult<T, I>
 where
     T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
-    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I> {
-        FlushedStream::new(flushed, Box::new(self))
+    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<T, I> {
+        FlushedStream::new(flushed, SubscriptionState::Subscribing(Box::new(self)))
     }
 }
-
-impl<T, I> Flushed<I> for SubscriptionStream<T, I>
-where
-    T: DuplexTransport + 'static,
-    I: serde::de::DeserializeOwned + 'static,
-{
-    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I> {
-        FlushedStream::new(flushed, Box::new(self))
-    }
-}
-

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -93,7 +93,7 @@ where
     /// # Arguments
     ///
     /// * `self` - Existing Stream that this is added to. Consumes self.
-    /// * `flsuhed` - Event that triggered flush
+    /// * `flushed` - Event that triggered flush
     fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<T, I>;
 }
 

--- a/src/extensions/flushed.rs
+++ b/src/extensions/flushed.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use web3::error::Error;
 use web3::futures::prelude::*;
 use web3::DuplexTransport;
+use web3::api::SubscriptionStream;
 
 use super::timeout::TimeoutStream;
 use crate::transfers::live::Event;
@@ -103,3 +104,14 @@ where
         FlushedStream::new(flushed, Box::new(self))
     }
 }
+
+impl<T, I> Flushed<I> for SubscriptionStream<T, I>
+where
+    T: DuplexTransport + 'static,
+    I: serde::de::DeserializeOwned + 'static,
+{
+    fn flushed(self, flushed: &Arc<RwLock<Option<Event>>>) -> FlushedStream<I> {
+        FlushedStream::new(flushed, Box::new(self))
+    }
+}
+

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,3 +1,3 @@
+pub mod flushed;
 pub mod removed;
 pub mod timeout;
-pub mod flushed;

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,2 +1,3 @@
 pub mod removed;
 pub mod timeout;
+pub mod flushed;

--- a/src/extensions/timeout.rs
+++ b/src/extensions/timeout.rs
@@ -2,39 +2,25 @@ use serde;
 use std::ops::Add;
 use std::time::{Duration, Instant};
 use tokio_core::reactor;
-use web3::api::{SubscriptionResult, SubscriptionStream};
 use web3::error::Error;
 use web3::futures::prelude::*;
-use web3::futures::try_ready;
 use web3::DuplexTransport;
 
-/// Enum for the two stages of subscribing to a timeout stream
-/// Subscribing holds a future that returns a TimeoutStream
-/// Subscribed holds a TimeoutStream
-pub enum SubscriptionState<T, I>
-where
-    T: DuplexTransport + 'static,
-    I: serde::de::DeserializeOwned + 'static,
-{
-    Subscribing(Box<dyn Future<Item = SubscriptionStream<T, I>, Error = web3::Error>>),
-    Subscribed(SubscriptionStream<T, I>),
-}
+use crate::extensions::flushed::FlushedStream;
 
 /// TimeoutStream adds a timeout to an existing Stream.
 /// returns Err if too much time has passed since the last object from the stream
-pub struct TimeoutStream<T, I>
+pub struct TimeoutStream<I>
 where
-    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
-    state: SubscriptionState<T, I>,
+    stream: Box<dyn Stream<Item = I, Error = web3::Error>>,
     duration: Duration,
     timeout: reactor::Timeout,
 }
 
-impl<T, I> TimeoutStream<T, I>
+impl<I> TimeoutStream<I>
 where
-    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     /// Returns a newly created TimeoutStream Stream
@@ -44,10 +30,14 @@ where
     /// * `stream` - Boxed stream to timeout
     /// * `duration` - Duration of time to trigger the timeout
     /// * `handle` - Handle to create a reactor::Timeout Future
-    pub fn new(state: SubscriptionState<T, I>, duration: Duration, handle: &reactor::Handle) -> Self {
+    pub fn new(
+        stream: Box<dyn Stream<Item = I, Error = web3::Error>>,
+        duration: Duration,
+        handle: &reactor::Handle,
+    ) -> Self {
         let timeout = reactor::Timeout::new(duration, handle).expect("error creating timeout");
         TimeoutStream {
-            state,
+            stream,
             duration,
             timeout,
         }
@@ -66,9 +56,8 @@ where
     }
 }
 
-impl<T, I> Stream for TimeoutStream<T, I>
+impl<I> Stream for TimeoutStream<I>
 where
-    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     type Item = I;
@@ -77,58 +66,44 @@ where
     /// Returns Items from the stream, or Err if timed out
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
-            let next = match self.state {
-                SubscriptionState::Subscribing(ref mut future) => {
-                    let stream = try_ready!(future.poll());
-                    Some(SubscriptionState::Subscribed(stream))
+            match self.stream.poll() {
+                // If the stream does not have the next element, check the timeout
+                Ok(Async::NotReady) => match self.timeout.poll() {
+                    // If the timeout is triggered, error out
+                    Ok(Async::Ready(_)) => {
+                        return Err(Error::Unreachable);
+                    }
+                    // If timeout not triggered, return NotReady
+                    Ok(Async::NotReady) => {
+                        return Ok(Async::NotReady);
+                    }
+                    // If timeout errors out, return error
+                    Err(_) => {
+                        error!("Timeout broken");
+                        return Err(Error::Internal);
+                    }
+                },
+                // If the stream returns an item, reset timeout and return the item
+                Ok(Async::Ready(Some(msg))) => {
+                    TimeoutStream::<I>::reset_timeout(&mut self.timeout, &self.duration);
+                    return Ok(Async::Ready(Some(msg)));
                 }
-                SubscriptionState::Subscribed(ref mut stream) => {
-                    match stream.poll() {
-                        // If the stream does not have the next element, check the timeout
-                        Ok(Async::NotReady) => match self.timeout.poll() {
-                            // If the timeout is triggered, error out
-                            Ok(Async::Ready(_)) => {
-                                return Err(Error::Unreachable);
-                            }
-                            // If timeout not triggered, return NotReady
-                            Ok(Async::NotReady) => {
-                                return Ok(Async::NotReady);
-                            }
-                            // If timeout errors out, return error
-                            Err(_) => {
-                                error!("Timeout broken");
-                                return Err(Error::Internal);
-                            }
-                        },
-                        // If the stream returns an item, reset timeout and return the item
-                        Ok(Async::Ready(Some(msg))) => {
-                            TimeoutStream::<T, I>::reset_timeout(&mut self.timeout, &self.duration);
-                            return Ok(Async::Ready(Some(msg)));
-                        }
-                        // Forward stream done
-                        Ok(Async::Ready(None)) => {
-                            return Ok(Async::Ready(None));
-                        }
-                        // Forward errors
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    };
+                // Forward stream done
+                Ok(Async::Ready(None)) => {
+                    return Ok(Async::Ready(None));
+                }
+                // Forward errors
+                Err(e) => {
+                    return Err(e);
                 }
             };
-            // If the Future finished, set the state to subscribed
-            if let Some(next_state) = next {
-                self.state = next_state;
-                TimeoutStream::<T, I>::reset_timeout(&mut self.timeout, &self.duration);
-            }
         }
     }
 }
 
 /// Trait to add to any Stream for creating a TimeoutStream via timeout()
-pub trait Timeout<T, I>
+pub trait Timeout<I>
 where
-    T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
     ///Returns a TimeoutStream that wraps the existing stream
@@ -138,18 +113,18 @@ where
     /// * `self` - Existing Stream that this is added to. Consumes self.
     /// * `duration` - Time in seconds to trigger a timeout
     /// # `handle` - Tokio reactor::Handle for Creating Timeout Future
-    fn timeout(self, duration: u64, handle: &reactor::Handle) -> TimeoutStream<T, I>;
+    fn timeout(self, duration: u64, handle: &reactor::Handle) -> TimeoutStream<I>;
 }
 
 /// Add Timeout trait to SubscriptionResult, which is returned by web3.eth_subscribe()
-impl<T, I> Timeout<T, I> for SubscriptionResult<T, I>
+impl<T, I> Timeout<I> for FlushedStream<T, I>
 where
     T: DuplexTransport + 'static,
     I: serde::de::DeserializeOwned + 'static,
 {
-    fn timeout(self, duration: u64, handle: &reactor::Handle) -> TimeoutStream<T, I> {
+    fn timeout(self, duration: u64, handle: &reactor::Handle) -> TimeoutStream<I> {
         let timeout = Duration::from_secs(duration);
         let handle = handle.clone();
-        TimeoutStream::new(SubscriptionState::Subscribing(Box::new(self)), timeout, &handle)
+        TimeoutStream::new(Box::new(self), timeout, &handle)
     }
 }

--- a/src/extensions/timeout.rs
+++ b/src/extensions/timeout.rs
@@ -69,13 +69,9 @@ where
             // If the stream does not have the next element, check the timeout
             Ok(Async::NotReady) => match self.timeout.poll() {
                 // If the timeout is triggered, error out
-                Ok(Async::Ready(_)) => {
-                    Err(Error::Unreachable)
-                }
+                Ok(Async::Ready(_)) => Err(Error::Unreachable),
                 // If timeout not triggered, return NotReady
-                Ok(Async::NotReady) => {
-                    Ok(Async::NotReady)
-                }
+                Ok(Async::NotReady) => Ok(Async::NotReady),
                 // If timeout errors out, return error
                 Err(_) => {
                     error!("Timeout broken");
@@ -88,13 +84,9 @@ where
                 Ok(Async::Ready(Some(msg)))
             }
             // Forward stream done
-            Ok(Async::Ready(None)) => {
-                Ok(Async::Ready(None))
-            }
+            Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
             // Forward errors
-            Err(e) => {
-                Err(e)
-            }
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/flush/check.rs
+++ b/src/flush/check.rs
@@ -5,7 +5,7 @@ use web3::types::{BlockNumber, FilterBuilder, Log, TransactionReceipt, U256, U64
 
 use crate::eth::contracts::FLUSH_EVENT_SIGNATURE;
 use crate::relay::Network;
-use crate::transfers::live::Event;
+use crate::eth::Event;
 use web3::DuplexTransport;
 
 enum CheckForPastFlushState {

--- a/src/flush/check.rs
+++ b/src/flush/check.rs
@@ -4,8 +4,8 @@ use web3::futures::try_ready;
 use web3::types::{BlockNumber, FilterBuilder, Log, TransactionReceipt, U256, U64};
 
 use crate::eth::contracts::FLUSH_EVENT_SIGNATURE;
-use crate::relay::Network;
 use crate::eth::Event;
+use crate::relay::Network;
 use web3::DuplexTransport;
 
 enum CheckForPastFlushState {

--- a/src/flush/process.rs
+++ b/src/flush/process.rs
@@ -8,9 +8,9 @@ use web3::types::{Address, BlockNumber, Bytes, TransactionReceipt, U256};
 use web3::DuplexTransport;
 
 use crate::eth::transaction::SendTransaction;
+use crate::eth::Event;
 use crate::flush::{CheckBalances, FilterLowBalance, Wallet};
 use crate::relay::Network;
-use crate::eth::Event;
 use crate::transfers::withdrawal::{ApproveParams, WaitForWithdrawalProcessed};
 
 enum ProcessFlushState<T: DuplexTransport + 'static> {

--- a/src/flush/process.rs
+++ b/src/flush/process.rs
@@ -10,7 +10,7 @@ use web3::DuplexTransport;
 use crate::eth::transaction::SendTransaction;
 use crate::flush::{CheckBalances, FilterLowBalance, Wallet};
 use crate::relay::Network;
-use crate::transfers::live::Event;
+use crate::eth::Event;
 use crate::transfers::withdrawal::{ApproveParams, WaitForWithdrawalProcessed};
 
 enum ProcessFlushState<T: DuplexTransport + 'static> {

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -22,7 +22,7 @@ use super::server::{HandleRequests, RequestType};
 use super::transfers::live::ProcessTransfer;
 use super::transfers::live::WatchLiveLogs;
 use super::transfers::past::RecheckPastTransferLogs;
-use crate::transfers::live::Event;
+use crate::eth::Event;
 
 const FREE_GAS_PRICE: u64 = 0;
 const GAS_LIMIT: u64 = 200_000;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,8 +1,7 @@
 use failure::{Error, SyncFailure};
 use lru::LruCache;
-use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::{process, time};
 use tokio_core::reactor;
 use web3::confirm::{wait_for_transaction_confirmation, SendTransactionWithConfirmation};
@@ -139,8 +138,8 @@ pub struct Network<T: DuplexTransport + 'static> {
     pub network_type: NetworkType,
     pub web3: Web3<T>,
     pub account: Address,
-    pub token: Rc<Contract<T>>,
-    pub relay: Rc<Contract<T>>,
+    pub token: Arc<Contract<T>>,
+    pub relay: Arc<Contract<T>>,
     pub free: bool,
     pub confirmations: u64,
     pub anchor_frequency: u64,
@@ -149,10 +148,10 @@ pub struct Network<T: DuplexTransport + 'static> {
     pub chain_id: u64,
     pub keydir: String,
     pub password: String,
-    pub nonce: Rc<AtomicUsize>,
-    pub pending: Rc<RwLock<LruCache<H256, TransferApprovalState>>>,
+    pub nonce: Arc<AtomicUsize>,
+    pub pending: Arc<RwLock<LruCache<H256, TransferApprovalState>>>,
     pub retries: u64,
-    pub flushed: Rc<RwLock<Option<Event>>>,
+    pub flushed: Arc<RwLock<Option<Event>>>,
 }
 
 impl<T: DuplexTransport + 'static> Network<T> {
@@ -199,12 +198,12 @@ impl<T: DuplexTransport + 'static> Network<T> {
             .parse()
             .or_else(|_| Err(OperationError::InvalidAddress(relay.into())))?;
 
-        let token = Rc::new(
+        let token = Arc::new(
             Contract::from_json(web3.eth(), token_address, token_abi.as_bytes())
                 .or(Err(OperationError::InvalidContractAbi))?,
         );
 
-        let relay = Rc::new(
+        let relay = Arc::new(
             Contract::from_json(web3.eth(), relay_address, relay_abi.as_bytes())
                 .or(Err(OperationError::InvalidContractAbi))?,
         );
@@ -223,10 +222,10 @@ impl<T: DuplexTransport + 'static> Network<T> {
             chain_id,
             keydir: keydir.to_string(),
             password: password.to_string(),
-            nonce: Rc::new(nonce),
-            pending: Rc::new(RwLock::new(LruCache::new(4096))),
+            nonce: Arc::new(nonce),
+            pending: Arc::new(RwLock::new(LruCache::new(4096))),
             retries,
-            flushed: Rc::new(RwLock::new(None)),
+            flushed: Arc::new(RwLock::new(None)),
         })
     }
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -110,7 +110,8 @@ impl<T: DuplexTransport + 'static> Relay<T> {
                         .and_then(|_| Ok(())),
                 )
             })
-            .map_err(|_| {
+            .map_err(|e| {
+                error!("error at top level: {:?}", e);
                 process::exit(-1);
             })
     }

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -6,13 +6,14 @@ use web3::futures::future::{ok, Either, Future};
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
 use web3::futures::try_ready;
-use web3::types::{Address, Filter, Log, TransactionReceipt, H256, U256};
+use web3::types::{Address, Filter, Log, H256, U256};
 use web3::DuplexTransport;
 use web3::Error;
 
 use super::transfer::Transfer;
 use crate::extensions::flushed::{Flushed, FlushedStream};
 use crate::relay::{Network, TransferApprovalState};
+use crate::eth::Event;
 
 /// Enum for the two stages of subscribing to a timeout stream
 /// Subscribing holds a future that returns a TimeoutStream
@@ -26,20 +27,6 @@ where
     Subscribed(FlushedStream<I>),
 }
 
-#[derive(Clone)]
-pub struct Event {
-    pub log: Log,
-    pub receipt: TransactionReceipt,
-}
-
-impl Event {
-    pub fn new(log: &Log, receipt: &TransactionReceipt) -> Self {
-        Event {
-            log: log.clone(),
-            receipt: receipt.clone(),
-        }
-    }
-}
 
 /// Stream of events that have match the given filter.
 /// Passes the transaction receipt and log over the given tx upon confirmation (or removal)

--- a/src/transfers/live.rs
+++ b/src/transfers/live.rs
@@ -1,7 +1,6 @@
 use lru::LruCache;
 use std::sync::{PoisonError, RwLockWriteGuard};
 use tokio_core::reactor;
-use web3::api::SubscriptionStream;
 use web3::futures::future::{ok, Either, Future};
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
@@ -11,27 +10,14 @@ use web3::DuplexTransport;
 use web3::Error;
 
 use super::transfer::Transfer;
+use crate::eth::Event;
 use crate::extensions::flushed::{Flushed, FlushedStream};
 use crate::relay::{Network, TransferApprovalState};
-use crate::eth::Event;
-
-/// Enum for the two stages of subscribing to a timeout stream
-/// Subscribing holds a future that returns a TimeoutStream
-/// Subscribed holds a TimeoutStream
-pub enum SubscriptionState<T, I>
-where
-    T: DuplexTransport + 'static,
-    I: serde::de::DeserializeOwned + 'static,
-{
-    Subscribing(Box<dyn Future<Item = SubscriptionStream<T, I>, Error = web3::Error>>),
-    Subscribed(FlushedStream<I>),
-}
-
 
 /// Stream of events that have match the given filter.
 /// Passes the transaction receipt and log over the given tx upon confirmation (or removal)
 pub struct WatchLiveLogs<T: DuplexTransport + 'static> {
-    state: SubscriptionState<T, Log>,
+    stream: FlushedStream<T, Log>,
     handle: reactor::Handle,
     source: Network<T>,
     tx: mpsc::UnboundedSender<Event>,
@@ -50,11 +36,16 @@ impl<T: DuplexTransport + 'static> WatchLiveLogs<T> {
         tx: &mpsc::UnboundedSender<Event>,
         handle: &reactor::Handle,
     ) -> Self {
-        let future = Box::new(source.web3.clone().eth_subscribe().subscribe_logs(filter.clone()));
+        let stream = source
+            .web3
+            .clone()
+            .eth_subscribe()
+            .subscribe_logs(filter.clone())
+            .flushed(&source.flushed.clone());
 
         WatchLiveLogs {
             source: source.clone(),
-            state: SubscriptionState::Subscribing(future),
+            stream,
             handle: handle.clone(),
             tx: tx.clone(),
         }
@@ -93,46 +84,33 @@ impl<T: DuplexTransport + 'static> Future for WatchLiveLogs<T> {
     type Item = ();
     type Error = web3::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let handle = self.handle.clone();
         loop {
-            let handle = self.handle.clone();
-            let flushed = self.source.flushed.clone();
-            let next = match self.state {
-                SubscriptionState::Subscribing(ref mut future) => {
-                    let stream = try_ready!(future.poll());
-                    Some(SubscriptionState::Subscribed(stream.flushed(&flushed)))
+            match self.stream.poll() {
+                Ok(Async::Ready(Some(log))) => {
+                    // On receiving a valid log, spawn the waiting for a receipt, as it takes
+                    // 20 blocks which is 20 seconds or 300 seconds and we don't want to block
+                    handle.spawn(self.process_log(&log));
                 }
-                SubscriptionState::Subscribed(ref mut stream) => {
-                    match stream.poll() {
-                        Ok(Async::Ready(Some(log))) => {
-                            // On receiving a valid log, spawn the waiting for a receipt, as it takes
-                            // 20 blocks which is 20 seconds or 300 seconds and we don't want to block
-                            handle.spawn(self.process_log(&log));
-                        }
-                        Ok(Async::Ready(None)) => {
-                            self.tx.close().map_err(move |_| {
-                                error!("Unable to close sender");
-                                Error::Internal
-                            })?;
-                            return Ok(Async::Ready(()));
-                        }
-                        Ok(Async::NotReady) => {
-                            return Ok(Async::NotReady);
-                        }
-                        Err(e) => {
-                            error!("error reading transfer logs on {:?}. {:?}", self.source.network_type, e);
-                            self.tx.close().map_err(move |_| {
-                                error!("Unable to close sender");
-                                Error::Internal
-                            })?;
-                            return Err(e);
-                        }
-                    };
-                    None
+                Ok(Async::Ready(None)) => {
+                    self.tx.close().map_err(move |_| {
+                        error!("Unable to close sender");
+                        Error::Internal
+                    })?;
+                    return Ok(Async::Ready(()));
+                }
+                Ok(Async::NotReady) => {
+                    return Ok(Async::NotReady);
+                }
+                Err(e) => {
+                    error!("error reading transfer logs on {:?}. {:?}", self.source.network_type, e);
+                    self.tx.close().map_err(move |_| {
+                        error!("Unable to close sender");
+                        Error::Internal
+                    })?;
+                    return Err(e);
                 }
             };
-            if let Some(next_state) = next {
-                self.state = next_state;
-            }
         }
     }
 }

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -9,8 +9,8 @@ use web3::Error;
 
 use super::transfer::Transfer;
 use crate::eth::contracts::TRANSFER_EVENT_SIGNATURE;
-use crate::extensions::timeout::Timeout;
 use crate::extensions::flushed::Flushed;
+use crate::extensions::timeout::Timeout;
 use crate::relay::Network;
 
 pub const LOOKBACK_RANGE: u64 = 1_000;
@@ -44,8 +44,8 @@ impl CheckPastTransfers {
             .clone()
             .eth_subscribe()
             .subscribe_new_heads()
-            .timeout(timeout, &handle)
             .flushed(&flushed)
+            .timeout(timeout, &handle)
             .for_each(move |head| {
                     let web3 = web3.clone();
                     let handle = handle.clone();
@@ -204,16 +204,11 @@ impl RecheckPastTransferLogs {
         let handle = handle.clone();
         let target = target.clone();
         let source = source.clone();
-        let future = CheckPastTransfers::new(&source, &handle)
-            .for_each(move |transfer| {
-                let target = target.clone();
-                let handle = handle.clone();
-                ValidateAndApproveTransfer::new(&source, &target, &handle, &transfer)
-            })
-            .and_then(move |_| {
-                // This is only ever triggered when the FindMissedTransfers has an error, and closes the Sender.
-                Err(())
-            });
+        let future = CheckPastTransfers::new(&source, &handle).for_each(move |transfer| {
+            let target = target.clone();
+            let handle = handle.clone();
+            ValidateAndApproveTransfer::new(&source, &target, &handle, &transfer)
+        });
         RecheckPastTransferLogs(Box::new(future))
     }
 }

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -10,6 +10,7 @@ use web3::Error;
 use super::transfer::Transfer;
 use crate::eth::contracts::TRANSFER_EVENT_SIGNATURE;
 use crate::extensions::timeout::Timeout;
+use crate::extensions::flushed::Flushed;
 use crate::relay::Network;
 
 pub const LOOKBACK_RANGE: u64 = 1_000;
@@ -34,6 +35,7 @@ impl CheckPastTransfers {
         let confirmations = source.confirmations * 2;
         let web3 = source.web3.clone();
         let timeout = source.timeout;
+        let flushed = source.flushed.clone();
 
         let future = {
             let handle = handle.clone();
@@ -43,6 +45,7 @@ impl CheckPastTransfers {
             .eth_subscribe()
             .subscribe_new_heads()
             .timeout(timeout, &handle)
+            .flushed(&flushed)
             .for_each(move |head| {
                     let web3 = web3.clone();
                     let handle = handle.clone();


### PR DESCRIPTION
Stops all streams when the flush event is set in the relay. 
Also, adds additional protection against withdrawals between when the flush block is set, and when it is confirmed. 