### PR TITLE
Exit on lost ethereum client connection

### DIFF
--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -155,14 +155,14 @@ impl<T: DuplexTransport + 'static> WatchAnchors<T> {
     fn process_header(&self, header: &BlockHeader) {
         header
             .number
-            .map_or_else(|| self.no_block_number(), |number| self.spawn_to_anchor(number));
+            .map_or_else(|| self.no_block_number(), |number| self.send_anchor(number));
     }
 
     fn no_block_number(&self) {
         warn!("no block number in block head event on {:?}", self.source.network_type);
     }
 
-    fn spawn_to_anchor(&self, block_number: U64) {
+    fn send_anchor(&self, block_number: U64) {
         let tx = self.tx.clone();
         let network_type = self.source.network_type;
         let web3 = self.source.web3.clone();

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -21,7 +21,7 @@ pub struct Anchor {
 }
 
 impl Anchor {
-    ///Returns a ProcessAnchor Future to post the anchor to the ERC20Relay contract
+    ///Returns a SendTransaction Future to post the anchor to the ERC20Relay contract
     ///
     /// # Arguments
     ///
@@ -56,7 +56,7 @@ pub struct ProcessAnchors<T: DuplexTransport + 'static> {
 }
 
 impl<T: DuplexTransport + 'static> ProcessAnchors<T> {
-    /// Returns a newly created HandleAnchors Future
+    /// Returns a newly created ProcessAnchors Future
     ///
     /// # Arguments
     ///
@@ -120,7 +120,7 @@ pub struct WatchAnchors<T: DuplexTransport + 'static> {
 }
 
 impl<T: DuplexTransport + 'static> WatchAnchors<T> {
-    /// Returns a newly created FindAnchors Future
+    /// Returns a newly created WatchAnchors Future
     ///
     /// # Arguments
     ///

--- a/src/anchors/anchor.rs
+++ b/src/anchors/anchor.rs
@@ -5,7 +5,7 @@ use web3::contract::tokens::Tokenize;
 use web3::futures::prelude::*;
 use web3::futures::sync::mpsc;
 use web3::futures::try_ready;
-use web3::types::{BlockId, BlockNumber, H256, U64};
+use web3::types::{BlockHeader, BlockId, BlockNumber, H256, U64};
 use web3::DuplexTransport;
 
 use crate::eth::transaction::SendTransaction;
@@ -48,14 +48,14 @@ impl fmt::Display for Anchor {
 }
 
 /// Future to handle the Stream of anchors & post them to the chain
-pub struct HandleAnchors<T: DuplexTransport + 'static> {
+pub struct ProcessAnchors<T: DuplexTransport + 'static> {
     source: Network<T>,
     target: Network<T>,
-    stream: FindAnchors,
+    stream: mpsc::UnboundedReceiver<Anchor>,
     handle: reactor::Handle,
 }
 
-impl<T: DuplexTransport + 'static> HandleAnchors<T> {
+impl<T: DuplexTransport + 'static> ProcessAnchors<T> {
     /// Returns a newly created HandleAnchors Future
     ///
     /// # Arguments
@@ -63,21 +63,25 @@ impl<T: DuplexTransport + 'static> HandleAnchors<T> {
     /// * `source` - Network where the block headers are captured
     /// * `target` - Network where the headers will be anchored
     /// * `handle` - Handle to spawn new futures
-    pub fn new(source: &Network<T>, target: &Network<T>, handle: &reactor::Handle) -> Self {
+    pub fn new(
+        source: &Network<T>,
+        target: &Network<T>,
+        rx: mpsc::UnboundedReceiver<Anchor>,
+        handle: &reactor::Handle,
+    ) -> Self {
         let handle = handle.clone();
         let source = source.clone();
         let target = target.clone();
-        let stream = FindAnchors::new(&source, &handle);
-        HandleAnchors {
+        ProcessAnchors {
             source,
             target,
-            stream,
+            stream: rx,
             handle,
         }
     }
 }
 
-impl<T: DuplexTransport + 'static> Future for HandleAnchors<T> {
+impl<T: DuplexTransport + 'static> Future for ProcessAnchors<T> {
     type Item = ();
     type Error = ();
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -107,115 +111,133 @@ impl<T: DuplexTransport + 'static> Future for HandleAnchors<T> {
 }
 
 /// Stream of block headers on one chain to be posted to the other
-pub struct FindAnchors(mpsc::UnboundedReceiver<Anchor>);
+pub struct WatchAnchors<T: DuplexTransport + 'static> {
+    stream: Box<dyn Stream<Item = BlockHeader, Error = ()>>,
+    header: Option<BlockHeader>,
+    tx: mpsc::UnboundedSender<Anchor>,
+    source: Network<T>,
+    handle: reactor::Handle,
+}
 
-impl FindAnchors {
+impl<T: DuplexTransport + 'static> WatchAnchors<T> {
     /// Returns a newly created FindAnchors Future
     ///
     /// # Arguments
     ///
     /// * `source` - Network where the block headers are found
     /// * `handle` - Handle to spawn new futures
-    pub fn new<T: DuplexTransport + 'static>(source: &Network<T>, handle: &reactor::Handle) -> Self {
-        let (tx, rx) = mpsc::unbounded();
-        let future = {
-            let network_type = source.network_type;
-            let anchor_frequency = source.anchor_frequency;
-            let confirmations = source.confirmations;
-            let h = handle.clone();
-            let handle = handle.clone();
-            let web3 = source.web3.clone();
-            let timeout = source.timeout;
-            let flushed = source.flushed.clone();
+    pub fn new(source: &Network<T>, tx: mpsc::UnboundedSender<Anchor>, handle: &reactor::Handle) -> Self {
+        let network_type = source.network_type;
+        let h = handle.clone();
+        let handle = handle.clone();
+        let timeout = source.timeout;
+        let flushed = source.flushed.clone();
 
-            source
-                .web3
-                .eth_subscribe()
-                .subscribe_new_heads()
-                .flushed(&flushed)
-                .timeout(timeout, &h)
-                .for_each(move |head| {
-                    head.number.map_or_else(
-                        || {
-                            warn!("no block number in block head event on {:?}", network_type);
-                            Ok(())
-                        },
-                        |block_number| {
-                            let tx = tx.clone();
+        let block_stream = source
+            .web3
+            .eth_subscribe()
+            .subscribe_new_heads()
+            .flushed(&flushed)
+            .timeout(timeout, &h)
+            .map_err(move |e| {
+                error!("error in anchor stream on {:?}: {:?}", network_type, e);
+            });
 
-                            match block_number.checked_rem(anchor_frequency.into()).map(|u| u.low_u64()) {
-                                Some(c) if c == confirmations => {
-                                    let block_id = BlockId::Number(BlockNumber::Number(block_number - confirmations));
+        WatchAnchors {
+            stream: Box::new(block_stream),
+            header: None,
+            tx,
+            source: source.clone(),
+            handle,
+        }
+    }
 
-                                    handle.spawn(
-                                        web3.eth()
-                                            .block(block_id)
-                                            .and_then(move |block| match block {
-                                                Some(b) => {
-                                                    if b.number.is_none() {
-                                                        warn!("no block number in anchor block on {:?}", network_type);
-                                                        return Ok(());
-                                                    }
+    fn process_header(&self, header: &BlockHeader) {
+        header
+            .number
+            .map_or_else(|| self.no_block_number(), |number| self.spawn_to_anchor(number));
+    }
 
-                                                    if b.hash.is_none() {
-                                                        warn!("no block hash in anchor block on {:?}", network_type);
-                                                        return Ok(());
-                                                    }
+    fn no_block_number(&self) {
+        warn!("no block number in block head event on {:?}", self.source.network_type);
+    }
 
-                                                    let block_hash: H256 = b.hash.unwrap();
-                                                    let block_number: U64 = b.number.unwrap();
+    fn spawn_to_anchor(&self, block_number: U64) {
+        let tx = self.tx.clone();
+        let network_type = self.source.network_type;
+        let web3 = self.source.web3.clone();
+        let handle = self.handle.clone();
+        let confirmations = self.source.confirmations;
+        match block_number
+            .checked_rem(self.source.anchor_frequency.into())
+            .map(|u| u.low_u64())
+        {
+            Some(c) if c == self.source.confirmations => {
+                let block_id = BlockId::Number(BlockNumber::Number(block_number - confirmations));
 
-                                                    let anchor = Anchor {
-                                                        block_hash,
-                                                        block_number,
-                                                    };
-
-                                                    info!(
-                                                        "anchor block confirmed, anchoring on {:?}: {}",
-                                                        network_type, &anchor
-                                                    );
-
-                                                    tx.unbounded_send(anchor).unwrap();
-                                                    Ok(())
-                                                }
-                                                None => {
-                                                    warn!(
-                                                        "no block found for anchor confirmations on {:?}",
-                                                        network_type
-                                                    );
-                                                    Ok(())
-                                                }
-                                            })
-                                            .or_else(move |e| {
-                                                error!(
-                                                    "error waiting for anchor confirmations on {:?}: {:?}",
-                                                    network_type, e
-                                                );
-                                                Ok(())
-                                            }),
-                                    );
+                handle.spawn(
+                    web3.eth()
+                        .block(block_id)
+                        .and_then(move |block| match block {
+                            Some(b) => {
+                                if b.number.is_none() {
+                                    warn!("no block number in anchor block on {:?}", network_type);
+                                    return Ok(());
                                 }
-                                _ => (),
-                            };
 
+                                if b.hash.is_none() {
+                                    warn!("no block hash in anchor block on {:?}", network_type);
+                                    return Ok(());
+                                }
+
+                                let block_hash: H256 = b.hash.unwrap();
+                                let block_number: U64 = b.number.unwrap();
+
+                                let anchor = Anchor {
+                                    block_hash,
+                                    block_number,
+                                };
+
+                                info!("anchor block confirmed, anchoring on {:?}: {}", network_type, &anchor);
+
+                                tx.unbounded_send(anchor).unwrap();
+                                Ok(())
+                            }
+                            None => {
+                                warn!("no block found for anchor confirmations on {:?}", network_type);
+                                Ok(())
+                            }
+                        })
+                        .or_else(move |e| {
+                            error!("error waiting for anchor confirmations on {:?}: {:?}", network_type, e);
                             Ok(())
-                        },
-                    )
-                })
-                .map_err(move |e| {
-                    error!("error in anchor stream on {:?}: {:?}", network_type, e);
-                })
+                        }),
+                );
+            }
+            _ => (),
         };
-
-        handle.spawn(future);
-        FindAnchors(rx)
     }
 }
 
-impl Stream for FindAnchors {
-    type Item = Anchor;
+impl<T: DuplexTransport + 'static> Future for WatchAnchors<T> {
+    type Item = ();
     type Error = ();
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.0.poll()
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            if let Some(ref blockheader) = self.header {
+                self.process_header(blockheader);
+                self.header = None;
+            } else {
+                let header_option = try_ready!(self.stream.poll());
+                match header_option {
+                    Some(header) => {
+                        self.header = Some(header);
+                    }
+                    None => {
+                        return Ok(Async::Ready(()));
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -61,7 +61,6 @@ impl<T: DuplexTransport + 'static> Future for HandleRequests<T> {
                         .and_then(move |transfers| {
                             let handle = handle.clone();
                             let source = source.clone();
-                            let target = target.clone();
                             let futures: Vec<ValidateAndApproveTransfer<T>> = transfers
                                 .iter()
                                 .map(move |transfer| {

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -325,7 +325,7 @@ impl<T: DuplexTransport + 'static> FindTransferInTransaction<T> {
     pub fn new(source: &Network<T>, hash: &H256) -> Self {
         let web3 = source.web3.clone();
         let network_type = source.network_type;
-        let future = web3.clone().eth().transaction_receipt(*hash).map_err(move |e| {
+        let future = web3.eth().transaction_receipt(*hash).map_err(move |e| {
             error!("error getting transaction receipt on {:?}: {:?}", network_type, e);
         });
         let state = FindTransferState::FetchReceipt(Box::new(future));

--- a/src/transfers/past.rs
+++ b/src/transfers/past.rs
@@ -16,18 +16,137 @@ use crate::relay::Network;
 pub const LOOKBACK_RANGE: u64 = 1_000;
 pub const LOOKBACK_LEEWAY: u64 = 5;
 
-/// Stream of Transfer that were missed, either from downtime, or failed approvals
-pub struct CheckPastTransfers(mpsc::UnboundedReceiver<Transfer>);
+/// Future to handle the Stream of missed transfers by checking them, and approving them
+pub struct ProcessPastTransfers<T: DuplexTransport + 'static> {
+    stream: mpsc::UnboundedReceiver<Transfer>,
+    future: Option<ValidateAndApproveTransfer<T>>,
+    source: Network<T>,
+    target: Network<T>,
+    handle: reactor::Handle,
+}
 
-impl CheckPastTransfers {
-    /// Returns a newly created FindMissedTransfers Stream
+impl<T: DuplexTransport + 'static> ProcessPastTransfers<T> {
+    /// Returns a newly created ProcessPastTransfers Future
+    ///
+    /// # Arguments
+    ///
+    /// * `source` - Network where the missed transfers are captured
+    /// * `target` - Network where the transfer will be approved for a withdrawal
+    /// * `handle` - Handle to spawn new futures
+    pub fn new(
+        source: &Network<T>,
+        rx: mpsc::UnboundedReceiver<Transfer>,
+        target: &Network<T>,
+        handle: &reactor::Handle,
+    ) -> Self {
+        let handle = handle.clone();
+        let target = target.clone();
+        let source = source.clone();
+        ProcessPastTransfers {
+            stream: rx,
+            future: None,
+            source,
+            target,
+            handle,
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for ProcessPastTransfers<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            if let Some(ref mut future) = self.future {
+                try_ready!(future.poll());
+                self.future = None;
+            } else {
+                let transfer_option = try_ready!(self.stream.poll());
+                match transfer_option {
+                    Some(transfer) => {
+                        self.future = Some(ValidateAndApproveTransfer::new(
+                            &self.source,
+                            &self.target,
+                            &self.handle,
+                            &transfer,
+                        ))
+                    }
+                    None => {
+                        return Ok(Async::Ready(()));
+                    }
+                };
+            }
+        }
+    }
+}
+
+/// Future to check a transfer against the contract and approve is necessary
+pub struct ValidateAndApproveTransfer<T: DuplexTransport + 'static> {
+    source: Network<T>,
+    target: Network<T>,
+    handle: reactor::Handle,
+    transfer: Transfer,
+    future: Box<dyn Future<Item = bool, Error = ()>>,
+}
+
+impl<T: DuplexTransport + 'static> ValidateAndApproveTransfer<T> {
+    /// Returns a newly created HandleMissedTransfers Future
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - Network where the transfer will be approved for a withdrawal
+    /// * `handle` - Handle to spawn new futures
+    /// * `transfer` - Transfer event to check/approve
+    pub fn new(source: &Network<T>, target: &Network<T>, handle: &reactor::Handle, transfer: &Transfer) -> Self {
+        let network_type = target.network_type;
+        let future = transfer.check_withdrawal(&target, None).map_err(move |e| {
+            error!("error checking withdrawal for approval on {:?}: {:?}", network_type, e);
+        });
+
+        ValidateAndApproveTransfer {
+            source: source.clone(),
+            target: target.clone(),
+            handle: handle.clone(),
+            transfer: *transfer,
+            future: Box::new(future),
+        }
+    }
+}
+
+impl<T: DuplexTransport + 'static> Future for ValidateAndApproveTransfer<T> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let needs_approval = try_ready!(self.future.poll());
+        if needs_approval {
+            let source = self.source.clone();
+            let target = self.target.clone();
+            let handle = self.handle.clone();
+            info!(
+                "approving withdrawal on {:?} from missed transfer on {:?}: {:?}",
+                target.network_type, source.network_type, self.transfer
+            );
+            handle.spawn(self.transfer.approve_withdrawal(&source, &target));
+        }
+        Ok(Async::Ready(()))
+    }
+}
+
+/// Stream of Transfer that were missed, either from downtime, or failed approvals
+pub struct WatchPastTransfers(Box<dyn Future<Item = (), Error = ()>>);
+
+impl WatchPastTransfers {
+    /// Returns a newly created WatchPastTransfers Stream
     ///
     /// # Arguments
     ///
     /// * `source` - Network where the missed transfers are found
     /// * `handle` - Handle to spawn new futures
-    pub fn new<T: DuplexTransport + 'static>(source: &Network<T>, handle: &reactor::Handle) -> Self {
-        let (tx, rx) = mpsc::unbounded();
+    pub fn new<T: DuplexTransport + 'static>(
+        source: &Network<T>,
+        tx: mpsc::UnboundedSender<Transfer>,
+        handle: &reactor::Handle,
+    ) -> Self {
         let token_address = source.token.address();
         let relay_address = source.relay.address();
         let network_type = source.network_type;
@@ -172,104 +291,15 @@ impl CheckPastTransfers {
                 error!("error in block head stream on {:?}: {:?}", network_type, e);
             })
         };
-        handle.spawn(future);
-        CheckPastTransfers(rx)
+        WatchPastTransfers(Box::new(future))
     }
 }
 
-impl Stream for CheckPastTransfers {
-    type Item = Transfer;
-    type Error = ();
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.0.poll()
-    }
-}
-
-/// Future to handle the Stream of missed transfers by checking them, and approving them
-pub struct RecheckPastTransferLogs(Box<dyn Future<Item = (), Error = ()>>);
-
-impl RecheckPastTransferLogs {
-    /// Returns a newly created HandleMissedTransfers Future
-    ///
-    /// # Arguments
-    ///
-    /// * `source` - Network where the missed transfers are captured
-    /// * `target` - Network where the transfer will be approved for a withdrawal
-    /// * `handle` - Handle to spawn new futures
-    pub fn new<T: DuplexTransport + 'static>(
-        source: &Network<T>,
-        target: &Network<T>,
-        handle: &reactor::Handle,
-    ) -> Self {
-        let handle = handle.clone();
-        let target = target.clone();
-        let source = source.clone();
-        let future = CheckPastTransfers::new(&source, &handle).for_each(move |transfer| {
-            let target = target.clone();
-            let handle = handle.clone();
-            ValidateAndApproveTransfer::new(&source, &target, &handle, &transfer)
-        });
-        RecheckPastTransferLogs(Box::new(future))
-    }
-}
-
-impl Future for RecheckPastTransferLogs {
+impl Future for WatchPastTransfers {
     type Item = ();
     type Error = ();
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.0.poll()
-    }
-}
-
-/// Future to check a transfer against the contract and approve is necessary
-pub struct ValidateAndApproveTransfer<T: DuplexTransport + 'static> {
-    source: Network<T>,
-    target: Network<T>,
-    handle: reactor::Handle,
-    transfer: Transfer,
-    future: Box<dyn Future<Item = bool, Error = ()>>,
-}
-
-impl<T: DuplexTransport + 'static> ValidateAndApproveTransfer<T> {
-    /// Returns a newly created HandleMissedTransfers Future
-    ///
-    /// # Arguments
-    ///
-    /// * `target` - Network where the transfer will be approved for a withdrawal
-    /// * `handle` - Handle to spawn new futures
-    /// * `transfer` - Transfer event to check/approve
-    pub fn new(source: &Network<T>, target: &Network<T>, handle: &reactor::Handle, transfer: &Transfer) -> Self {
-        let network_type = target.network_type;
-        let future = transfer.check_withdrawal(&target, None).map_err(move |e| {
-            error!("error checking withdrawal for approval on {:?}: {:?}", network_type, e);
-        });
-
-        ValidateAndApproveTransfer {
-            source: source.clone(),
-            target: target.clone(),
-            handle: handle.clone(),
-            transfer: *transfer,
-            future: Box::new(future),
-        }
-    }
-}
-
-impl<T: DuplexTransport + 'static> Future for ValidateAndApproveTransfer<T> {
-    type Item = ();
-    type Error = ();
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let needs_approval = try_ready!(self.future.poll());
-        if needs_approval {
-            let source = self.source.clone();
-            let target = self.target.clone();
-            let handle = self.handle.clone();
-            info!(
-                "approving withdrawal on {:?} from missed transfer on {:?}: {:?}",
-                target.network_type, source.network_type, self.transfer
-            );
-            handle.spawn(self.transfer.approve_withdrawal(&source, &target));
-        }
-        Ok(Async::Ready(()))
     }
 }
 


### PR DESCRIPTION
There were two causes for this bug
1. Flush was reconnecting the subscription on errors
1. The `TimeoutStream`s were spawned, and the error didn't bubble up

